### PR TITLE
feat(libei): portal restore_token cache + recovery flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,6 +1290,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",

--- a/wdotool-core/Cargo.toml
+++ b/wdotool-core/Cargo.toml
@@ -18,6 +18,8 @@ libei = [
     "dep:enumflags2",
     "dep:futures-util",
     "dep:reis",
+    "dep:serde",
+    "dep:serde_json",
     "dep:xkbcommon",
 ]
 wlroots = [
@@ -57,3 +59,6 @@ wayland-protocols-wlr = { version = "0.3", features = ["client"], optional = tru
 xkbcommon = { version = "0.9", features = ["wayland"], optional = true }
 xkeysym = { version = "0.2", optional = true }
 zbus = { version = "5", default-features = false, features = ["tokio"], optional = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/wdotool-core/src/backend/libei.rs
+++ b/wdotool-core/src/backend/libei.rs
@@ -19,11 +19,12 @@ use futures_util::StreamExt;
 use reis::ei;
 use reis::event::{self as rev, DeviceCapability, EiEvent};
 use tokio::sync::oneshot;
-use tracing::{debug, trace, warn};
+use tracing::{debug, info, trace, warn};
 use xkbcommon::xkb;
 
 use super::Backend;
 use crate::error::{Result, WdoError};
+use crate::portal_token;
 use crate::types::{Capabilities, KeyDirection, MouseButton, WindowId, WindowInfo};
 
 const NAME: &str = "libei";
@@ -254,23 +255,71 @@ async fn open_context() -> Result<ei::Context> {
         .create_session(CreateSessionOptions::default())
         .await
         .map_err(portal_err)?;
-    remote
-        .select_devices(
-            &session,
-            SelectDevicesOptions::default()
-                .set_devices(DeviceType::Keyboard | DeviceType::Pointer)
-                .set_persist_mode(PersistMode::DoNot),
-        )
-        .await
-        .map_err(portal_err)?
-        .response()
-        .map_err(portal_err)?;
-    remote
-        .start(&session, None, StartOptions::default())
-        .await
-        .map_err(portal_err)?
-        .response()
-        .map_err(portal_err)?;
+
+    // Recovery flow for the portal restore_token. Without this cache,
+    // every wdotool invocation pops a consent dialog. With it: the
+    // first run prompts once, every subsequent run is silent until the
+    // user revokes.
+    //
+    // Algorithm:
+    //   1. Read the cached token (best-effort — any read failure
+    //      degrades to "no token, run first-run consent flow").
+    //   2. Try select_devices with the cached token attached.
+    //   3. On success → keep the (possibly new) token from the
+    //      response. On any error AND we had a cached token → retry
+    //      once without the token (forces the consent dialog).
+    //   4. On the retry, save whatever new token comes back. If retry
+    //      ALSO fails (e.g., user denies consent, compositor crashed
+    //      between the two attempts), keep the OLD cached file
+    //      untouched so the next session can still try it — the
+    //      compositor might have been hiccupping. Propagate the error.
+    //
+    // Error-class refinement is deferred: ashpd 0.13 doesn't expose a
+    // clean "token-invalid" variant, so v0.2.0 retries on ANY error
+    // from the with-token path. Real-world testing on KDE + GNOME
+    // (issue #1) will tell us which ashpd error variants represent
+    // transient vs. token-invalid failures, and a follow-up can
+    // narrow the retry condition.
+    let cached = match portal_token::load() {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(error = ?e, "couldn't read portal token cache, treating as missing");
+            None
+        }
+    };
+
+    let used_cached = cached.is_some();
+    let cached_token: Option<String> = cached.as_ref().map(|c| c.token.clone());
+
+    // run_session_flow runs select_devices + start. Start's response
+    // is what carries the freshly-issued restore_token, so both calls
+    // need to live inside the retry boundary.
+    let selected = match run_session_flow(&remote, &session, cached_token.as_deref()).await {
+        Ok(devices) => devices,
+        Err(first_err) if used_cached => {
+            info!(
+                error = %first_err,
+                "cached portal token did not satisfy session start, retrying with consent dialog"
+            );
+            run_session_flow(&remote, &session, None)
+                .await
+                .map_err(portal_err)?
+        }
+        Err(err) => return Err(portal_err(err)),
+    };
+
+    // Only persist on Some. The portal can return None on a successful
+    // start (e.g., user opted out of "remember this choice"); in that
+    // case leaving the previous cache untouched is correct — a stale
+    // token will trigger the retry path next time and get refreshed
+    // there.
+    if let Some(new_token) = selected.restore_token() {
+        let backend = detect_portal_backend();
+        if let Err(e) = portal_token::save(new_token, backend) {
+            warn!(error = ?e, "couldn't persist portal token, session still works");
+        }
+    }
+
     let fd = remote
         .connect_to_eis(&session, ConnectToEISOptions::default())
         .await
@@ -280,6 +329,40 @@ async fn open_context() -> Result<ei::Context> {
         backend: NAME,
         source: Box::new(e),
     })
+}
+
+async fn run_session_flow(
+    remote: &RemoteDesktop,
+    session: &ashpd::desktop::Session<RemoteDesktop>,
+    restore_token: Option<&str>,
+) -> ashpd::Result<ashpd::desktop::remote_desktop::SelectedDevices> {
+    let select_opts = SelectDevicesOptions::default()
+        .set_devices(DeviceType::Keyboard | DeviceType::Pointer)
+        .set_persist_mode(PersistMode::ExplicitlyRevoked)
+        .set_restore_token(restore_token);
+    remote
+        .select_devices(session, select_opts)
+        .await?
+        .response()?;
+    remote
+        .start(session, None, StartOptions::default())
+        .await?
+        .response()
+}
+
+/// Best-effort identifier of which portal backend issued the token.
+/// Diagnostic only — the retry-without-token recovery flow handles
+/// backend switches even if the cached `portal_backend` is wrong.
+fn detect_portal_backend() -> &'static str {
+    let desktop = std::env::var("XDG_CURRENT_DESKTOP").unwrap_or_default();
+    let lower = desktop.to_lowercase();
+    if lower.contains("gnome") {
+        "gnome"
+    } else if lower.contains("kde") {
+        "kde"
+    } else {
+        "other"
+    }
 }
 
 fn portal_err(e: ashpd::Error) -> WdoError {

--- a/wdotool-core/src/lib.rs
+++ b/wdotool-core/src/lib.rs
@@ -22,6 +22,9 @@ pub mod error;
 pub mod keysym;
 pub mod types;
 
+#[cfg(feature = "libei")]
+pub(crate) mod portal_token;
+
 pub use backend::detector;
 pub use backend::{Backend, DynBackend};
 pub use error::{Result, WdoError};

--- a/wdotool-core/src/portal_token.rs
+++ b/wdotool-core/src/portal_token.rs
@@ -1,0 +1,314 @@
+//! Portal restore_token cache for the libei backend.
+//!
+//! The XDG RemoteDesktop portal can issue a `restore_token` after the
+//! user grants consent. Future sessions that present the same token
+//! skip the consent dialog (the portal validates the token against the
+//! user's stored grant). Without this cache, every `wdotool` invocation
+//! on GNOME / KDE / any xdg-portal-supporting compositor pops a fresh
+//! consent dialog, which makes a 20-step wflow workflow impossible to
+//! actually run.
+//!
+//! The cache is best-effort: load failures (missing file, malformed
+//! JSON, unknown schema) all degrade gracefully to "no cached token,
+//! run first-time consent flow." Only OS-level errors propagate.
+//!
+//! On-disk format: `$XDG_STATE_HOME/wdotool/portal.token`, mode 0600,
+//! containing JSON with a `schema_version` field. Bumps to the schema
+//! version invalidate older caches (load() treats them as "no cached
+//! token" and the next session re-issues one).
+
+use std::fs;
+use std::io;
+use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+/// The current cache schema. Bump on incompatible field changes;
+/// `load()` treats unknown versions as "no cached token."
+const SCHEMA_VERSION: u32 = 1;
+
+/// Cached portal restore_token + metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct CachedToken {
+    pub schema_version: u32,
+    pub token: String,
+    /// Best-effort identifier of the portal backend that issued the
+    /// token (`"gnome"` / `"kde"` / `"other"`). Diagnostic only — the
+    /// retry-without-token recovery flow handles backend switches.
+    pub portal_backend: String,
+    /// `env!("CARGO_PKG_VERSION")` at the time of the save.
+    pub wdotool_version: String,
+    pub created_at_unix: u64,
+}
+
+/// Resolve the cache file path: `$XDG_STATE_HOME/wdotool/portal.token`,
+/// falling back to `$HOME/.local/state/wdotool/portal.token`. Returns
+/// `None` only when neither env var resolves (shouldn't happen in any
+/// normal session, but we don't want to panic on malformed environments).
+pub(crate) fn cache_path() -> Option<PathBuf> {
+    state_dir().map(|d| cache_path_in(&d))
+}
+
+fn state_dir() -> Option<PathBuf> {
+    if let Some(state) = std::env::var_os("XDG_STATE_HOME") {
+        let path = PathBuf::from(state);
+        if path.is_absolute() {
+            return Some(path);
+        }
+    }
+    std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/state"))
+}
+
+fn cache_path_in(state_dir: &Path) -> PathBuf {
+    state_dir.join("wdotool").join("portal.token")
+}
+
+/// Load the cached token, if any.
+///
+/// Returns `Ok(None)` for: missing file, malformed JSON, unknown
+/// `schema_version`. Returns `Err(_)` only on unexpected I/O errors
+/// (permission denied, EIO, etc.).
+pub(crate) fn load() -> io::Result<Option<CachedToken>> {
+    let Some(path) = cache_path() else {
+        return Ok(None);
+    };
+    load_from(&path)
+}
+
+fn load_from(path: &Path) -> io::Result<Option<CachedToken>> {
+    let contents = match fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    match serde_json::from_str::<CachedToken>(&contents) {
+        Ok(t) if t.schema_version == SCHEMA_VERSION => Ok(Some(t)),
+        Ok(t) => {
+            warn!(
+                schema_version = t.schema_version,
+                expected = SCHEMA_VERSION,
+                "ignoring portal token cache: unknown schema_version"
+            );
+            Ok(None)
+        }
+        Err(e) => {
+            warn!(
+                error = %e,
+                path = %path.display(),
+                "ignoring portal token cache: malformed JSON"
+            );
+            Ok(None)
+        }
+    }
+}
+
+/// Save a freshly-issued token to the cache atomically.
+///
+/// - Creates the parent directory with mode 0700 if missing.
+/// - Writes to a pid-suffixed tmp file with mode 0600 set at create
+///   time via `OpenOptions::mode(0o600)`. Setting the mode at create
+///   (rather than chmod-after-write) closes the umask race window
+///   where another local process could read the token before the
+///   chmod lands.
+/// - `rename(2)` to the final path. Atomic on the same filesystem.
+pub(crate) fn save(token: &str, portal_backend: &str) -> io::Result<()> {
+    let Some(path) = cache_path() else {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "no XDG_STATE_HOME or HOME — cannot persist portal token",
+        ));
+    };
+    save_to(&path, token, portal_backend)
+}
+
+fn save_to(path: &Path, token: &str, portal_backend: &str) -> io::Result<()> {
+    use std::io::Write;
+
+    if let Some(parent) = path.parent() {
+        match fs::metadata(parent) {
+            Ok(meta) if meta.is_dir() => {}
+            Ok(_) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    "cache parent path exists but is not a directory",
+                ));
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                fs::DirBuilder::new()
+                    .recursive(true)
+                    .mode(0o700)
+                    .create(parent)?;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let cached = CachedToken {
+        schema_version: SCHEMA_VERSION,
+        token: token.to_owned(),
+        portal_backend: portal_backend.to_owned(),
+        wdotool_version: env!("CARGO_PKG_VERSION").to_owned(),
+        created_at_unix: now,
+    };
+    let payload = serde_json::to_vec_pretty(&cached)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+    // Pid-suffixed tmp name so concurrent writers from different
+    // processes don't trample each other's tmp file. create_new flag
+    // means open fails (instead of clobbering) if the tmp already
+    // exists.
+    let tmp_path = path.with_file_name(format!("portal.token.tmp.{}", std::process::id()));
+
+    let write_result: io::Result<()> = (|| {
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&tmp_path)?;
+        f.write_all(&payload)?;
+        // Best-effort fsync — durability isn't load-bearing for a
+        // regenerable token cache, but lowers the chance of an empty
+        // file surviving a power loss between write and rename.
+        let _ = f.sync_all();
+        Ok(())
+    })();
+
+    if let Err(e) = write_result {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+
+    // rename(2) is atomic on the same filesystem; the receiving open()
+    // either sees the old file or the new file, never a half-written one.
+    if let Err(e) = fs::rename(&tmp_path, path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::tempdir;
+
+    fn cache_in(dir: &Path) -> PathBuf {
+        cache_path_in(dir)
+    }
+
+    #[test]
+    fn load_returns_none_for_missing_file() {
+        let dir = tempdir().unwrap();
+        let path = cache_in(dir.path());
+        assert!(load_from(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn load_returns_none_for_malformed_json() {
+        let dir = tempdir().unwrap();
+        let path = cache_in(dir.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "{ this is not json").unwrap();
+        assert!(load_from(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn load_returns_none_for_unknown_schema_version() {
+        let dir = tempdir().unwrap();
+        let path = cache_in(dir.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let payload = r#"{
+            "schema_version": 99,
+            "token": "abc",
+            "portal_backend": "gnome",
+            "wdotool_version": "0.99.0",
+            "created_at_unix": 1
+        }"#;
+        fs::write(&path, payload).unwrap();
+        assert!(load_from(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = tempdir().unwrap();
+        let path = cache_in(dir.path());
+        save_to(&path, "secret-token", "gnome").unwrap();
+        let loaded = load_from(&path).unwrap().expect("token must load back");
+        assert_eq!(loaded.schema_version, SCHEMA_VERSION);
+        assert_eq!(loaded.token, "secret-token");
+        assert_eq!(loaded.portal_backend, "gnome");
+        assert_eq!(loaded.wdotool_version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn save_creates_parent_dir_with_mode_0700() {
+        let dir = tempdir().unwrap();
+        let path = cache_in(dir.path());
+        let parent = path.parent().unwrap();
+        assert!(!parent.exists());
+        save_to(&path, "tok", "kde").unwrap();
+        let meta = fs::metadata(parent).unwrap();
+        assert!(meta.is_dir());
+        // Mask off the file-type bits and check that no group/world
+        // permissions made it through.
+        let mode = meta.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "parent dir mode = {mode:o}, want 0700");
+    }
+
+    #[test]
+    fn save_writes_file_with_mode_0600() {
+        let dir = tempdir().unwrap();
+        let path = cache_in(dir.path());
+        save_to(&path, "tok", "gnome").unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "cache file mode = {mode:o}, want 0600");
+    }
+
+    #[test]
+    fn save_overwrites_existing_cache_atomically() {
+        let dir = tempdir().unwrap();
+        let path = cache_in(dir.path());
+        save_to(&path, "first", "gnome").unwrap();
+        save_to(&path, "second", "kde").unwrap();
+        let loaded = load_from(&path).unwrap().unwrap();
+        assert_eq!(loaded.token, "second");
+        assert_eq!(loaded.portal_backend, "kde");
+        // No leftover .tmp files in the directory.
+        let leftovers: Vec<_> = fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+            .collect();
+        assert!(leftovers.is_empty(), "leftover tmp files: {leftovers:?}");
+    }
+
+    #[test]
+    fn save_propagates_eacces_when_parent_unwritable() {
+        let dir = tempdir().unwrap();
+        // Point the cache at a deep path under a read-only directory:
+        // the parent-dir creation hits EACCES.
+        let ro = dir.path().join("readonly");
+        fs::create_dir(&ro).unwrap();
+        let mut perms = fs::metadata(&ro).unwrap().permissions();
+        perms.set_mode(0o500);
+        fs::set_permissions(&ro, perms).unwrap();
+
+        let path = cache_in(&ro.join("blocked"));
+        let err = save_to(&path, "tok", "gnome").unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+
+        // Restore permissions so tempdir cleanup works.
+        let mut perms = fs::metadata(&ro).unwrap().permissions();
+        perms.set_mode(0o700);
+        fs::set_permissions(&ro, perms).unwrap();
+    }
+}


### PR DESCRIPTION
Fixes the consent dialog spam that made wflow unusable on GNOME and KDE.

Before this PR, every `wdotool key ctrl+c` on GNOME or KDE pops an "Allow this app to control your computer?" portal dialog. A 20-step wflow workflow needs 20 consent clicks. Genuinely unusable.

After: the first run shows the dialog once. The portal hands back a `restore_token` we save to `~/.local/state/wdotool/portal.token` (mode 0600). Future runs present the token and skip the dialog. Stays silent until the user revokes consent in their portal settings, then the next run prompts again to issue a fresh token.

The cache lives in a new `portal_token` module in wdotool-core, gated behind the libei feature since only libei uses it. Atomic write via tmp file + rename. Mode 0600 set at create time via `OpenOptions::mode(0o600)` rather than chmod after writing, which would leave a window where another local process could read the token. Best-effort reads: missing file, malformed JSON, or unknown schema version all fall through to "no cached token, run the consent flow." Only OS-level errors propagate.

The recovery flow in libei.rs is the load-bearing piece. The naive "retry on any error" pattern has three subtle bugs that an adversarial review caught:

A compositor crash mid-retry would clobber a still-valid cached token. A user denying consent on the retry would also clobber. And a successful start with `restore_token: None` (the portal is allowed to do that) would overwrite a working cache with nothing. The actual algorithm avoids all three. Code comments at the call site walk through which error gets which treatment.

Real-world refinement is deferred. ashpd 0.13 doesn't expose a clean "token-invalid" variant, so v0.2.0 retries on any error from the with-token path. After live KDE and GNOME testing, we'll know which ashpd error variants need narrower handling and can refine the match.

I added 8 unit tests for the cache layer (round-trip, mode bits, parent dir creation, atomic rename leftover cleanup, EACCES propagation). The token-revoke recovery itself isn't automated. GitHub Actions has no Wayland session, and there's no off-the-shelf containerized GNOME-with-portals image, so calling it "tested in CI" would have been a sham. It's a manual checklist cell in the KDE verification matrix instead.

Item 2 of v0.2.0.