### PR TITLE
feat: wdotool diag command + README/CHANGELOG for v0.2.0 progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `wdotool diag` and `wdotool diag --copy`. Environment + backend availability report meant for bug triage. Probes pre-conditions only (XDG env vars, portal availability via `busctl`, GNOME extension presence, `/dev/uinput` writability, portal token cache state), so the diag run never opens a portal session and never pops a consent dialog. Markdown by default, `--json` for machine-readable output, `--copy` pipes the markdown through `wl-copy` (falling back to `xclip`).
+- libei portal token cache. The first run prompts the user for consent. The portal-issued `restore_token` is cached at `$XDG_STATE_HOME/wdotool/portal.token` (mode 0600 set at create time via `OpenOptions::mode(0o600)`). Subsequent runs present the token and skip the dialog. The recovery flow detects token rejection and re-runs the consent flow without clobbering a still-valid cache on transient failures. Delete the cache file to force a fresh consent.
+- Per-backend Cargo features (`libei`, `wlroots`, `kde`, `gnome`, `uinput`) on the new `wdotool-core` library crate. Default-on enables all five. Downstream Rust consumers can opt out: `default-features = false, features = ["libei", "wlroots", "kde", "gnome"]` drops uinput's `input-linux` and `libc` deps.
+
+### Changed
+- Repo is now a Cargo workspace. The engine moved into `wdotool-core/` (a library crate); the `wdotool` binary is a thin clap wrapper that depends on `wdotool-core`. End-user behavior is unchanged. Other Rust projects can `cargo add wdotool-core` and call the engine directly instead of subprocessing the binary.
+- `WdoError::Backend.source` type changed from `anyhow::Error` to `Box<dyn std::error::Error + Send + Sync>`. `wdotool-core` no longer pulls `anyhow` into its dependents.
+- libei's `select_devices` switched from `PersistMode::DoNot` to `PersistMode::ExplicitlyRevoked` so the portal actually issues restore tokens.
+- Workspace MSRV pin: Rust 1.82+ (the CLI uses `Option::is_none_or`).
+
 ## [0.1.6] — 2026-04-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,8 @@ version = "0.1.6"
 dependencies = [
  "anyhow",
  "clap",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing-subscriber",
  "wdotool-core",

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Early but usable. Actively tested on Hyprland + wlroots. The KDE and GNOME backe
 
 ³ Implemented but unverified on a real Plasma session ([issue #1](https://github.com/cushycush/wdotool/issues/1)).
 
-⁴ **Experimental.** Requires the companion GNOME Shell extension in `packaging/gnome-extension/wdotool@wdotool.github.io/` — see [issue #2](https://github.com/cushycush/wdotool/issues/2). Shipped but unverified on a live GNOME session; please try it and file issues. Without the extension, `gnome` falls back to bare libei (input only).
+⁴ Requires the companion GNOME Shell extension at `packaging/gnome-extension/wdotool@wdotool.github.io/`. Shipped in v0.1.6 but not yet smoke-tested on a real GNOME session; if you run GNOME, please try it and file [issue #2](https://github.com/cushycush/wdotool/issues/2) if anything breaks. Without the extension, `gnome` falls back to bare libei (input only).
 
 ## Install
 
@@ -70,6 +70,8 @@ Drop-in xdotool replacement for the common commands:
 
 ```sh
 wdotool info                              # show detected backend + capabilities
+wdotool diag                              # env + backend availability report
+wdotool diag --copy                       # same, piped to the clipboard for bug reports
 
 wdotool key ctrl+c                        # send Ctrl+C
 wdotool keydown shift                     # press and hold Shift
@@ -109,6 +111,14 @@ Global flags:
 
 Opens an `org.freedesktop.portal.RemoteDesktop` session via the XDG portal, negotiates a libei socket, handshakes as a sender context, and emits input through the compositor's own libei implementation. Full focus awareness and permission prompts. **Preferred on GNOME and KDE.**
 
+The portal asks for consent on the first run (a "Allow this app to control your computer?" dialog). wdotool caches the issued `restore_token` at `$XDG_STATE_HOME/wdotool/portal.token` (mode 0600). Every later run presents the token and skips the dialog. The flow stays silent until the user revokes from the portal's settings UI, then the next run prompts again.
+
+To reset the consent flow manually, delete the cache file:
+
+```sh
+rm ~/.local/state/wdotool/portal.token
+```
+
 **Requirements:**
 - `xdg-desktop-portal` + a backend that exports `org.freedesktop.portal.RemoteDesktop`. `xdg-desktop-portal-gnome` (GNOME 46+) and `xdg-desktop-portal-kde` (KDE Plasma 6) both ship it.
 - On Hyprland, `xdg-desktop-portal-hyprland` 1.3.11 does **not** yet expose RemoteDesktop. Use the wlroots backend instead.
@@ -128,21 +138,21 @@ Composes libei (for input) with KWin-scripting window management over D-Bus. Gen
 - `xdg-desktop-portal-kde` for the libei input path.
 - KWin 5.22+ for the Scripting D-Bus interface.
 
-### gnome (experimental)
+### gnome
 
-Pairs libei (for input, via GNOME's RemoteDesktop portal) with a companion GNOME Shell extension that exposes `ListWindows` / `GetActiveWindow` / `ActivateWindow` / `CloseWindow` on the session bus. GNOME Shell has no generic external window API, so the extension is mandatory for window management — without it, the detector falls back to bare libei automatically.
+Pairs libei (for input, via GNOME's RemoteDesktop portal) with a companion GNOME Shell extension that exposes `ListWindows`, `GetActiveWindow`, `ActivateWindow`, and `CloseWindow` on the session bus. GNOME Shell has no generic external window API, so the extension is the only way to do window management. Without the extension, the detector falls back to bare libei (input only) automatically.
 
-**Status:** shipped in v0.1.6 but not yet dogfooded on a live GNOME session (development machine is Hyprland). Please try it and open issues for anything that misbehaves — see [#2](https://github.com/cushycush/wdotool/issues/2).
+**Status:** shipped in v0.1.6 but the project is maintained from Hyprland, so the GNOME backend has not been smoke-tested on a real session yet. If you run GNOME, install the extension and try a few `wdotool` commands. Bug reports go to [#2](https://github.com/cushycush/wdotool/issues/2). `wdotool diag` will tell you whether the extension is found.
 
 **Requirements:**
 - `xdg-desktop-portal-gnome` for the libei input path (GNOME 46+ ships it).
 - The `wdotool@wdotool.github.io` extension, installable from `packaging/gnome-extension/`:
   ```sh
   cp -r packaging/gnome-extension/wdotool@wdotool.github.io ~/.local/share/gnome-shell/extensions/
-  # log out + log back in, then enable:
+  # log out, log back in, then enable:
   gnome-extensions enable wdotool@wdotool.github.io
   ```
-  The extension targets GNOME Shell 45–48. No background activity — it only handles D-Bus method calls from the wdotool CLI.
+  The extension targets GNOME Shell 45 through 48. It has no background activity; it only responds to D-Bus method calls from the wdotool CLI.
 
 ### uinput
 
@@ -170,14 +180,44 @@ Creates a virtual input device via `/dev/uinput` and writes raw `input_event` st
 
 Backend selection is automatic based on `XDG_CURRENT_DESKTOP` and compositor hints (`SWAYSOCK`, `HYPRLAND_INSTANCE_SIGNATURE`, etc.). The detector tries the preferred backend first and falls through to alternatives if it fails to bootstrap — use `--backend` to force a specific one.
 
+## Use as a library
+
+The engine lives in a separate `wdotool-core` crate, so other Rust projects can drive input directly without spawning a subprocess. The CLI is a thin wrapper around the same crate.
+
+```toml
+# Cargo.toml
+[dependencies]
+wdotool-core = "0.1"
+```
+
+Each backend is gated behind a Cargo feature (`libei`, `wlroots`, `kde`, `gnome`, `uinput`). Default-on enables all five. To skip a backend, opt out:
+
+```toml
+# Drop uinput's input-linux + libc deps; useful in sandboxed builds (Flatpak)
+# where /dev/uinput is not reachable.
+wdotool-core = { version = "0.1", default-features = false, features = ["libei", "wlroots", "kde", "gnome"] }
+```
+
+Public API (intentionally small):
+
+```rust
+use wdotool_core::{detector, Backend, KeyDirection, MouseButton};
+
+let env = detector::Environment::detect();
+let backend = detector::build(&env, None).await?;
+backend.key("ctrl+c", KeyDirection::PressRelease).await?;
+```
+
+The full list: `Backend` trait, `DynBackend`, `detector::{build, Environment, BackendKind}`, `keysym::parse_chain`, the value types (`Capabilities`, `WindowInfo`, etc.), and `WdoError` / `Result`. Per-backend types stay private; you build through `detector::build`.
+
 ## Building
 
 Requires Rust 1.82+ (the CLI uses `Option::is_none_or`). Builds cleanly on stable.
 
 ```sh
-cargo build             # dev
-cargo build --release   # ~4 MB stripped binary
-cargo test              # unit tests
+cargo build             # dev (workspace root builds both crates)
+cargo build --release   # release binary at target/release/wdotool
+cargo test              # 32 unit tests across both crates
 ```
 
 System libraries at build time: `libxkbcommon-dev` and `libwayland-dev` (Debian/Ubuntu names; same underlying libraries elsewhere).
@@ -193,33 +233,42 @@ System libraries at build time: `libxkbcommon-dev` and `libwayland-dev` (Debian/
 
 ## Project layout
 
+The repo is a Cargo workspace with two crates.
+
 ```
-src/
-  main.rs            # CLI entry (tokio)
-  cli.rs             # clap subcommand definitions
-  error.rs           # WdoError
-  types.rs           # Capabilities, KeyDirection, MouseButton, WindowInfo
-  keysym.rs          # ctrl+shift+a parser
-  backend/
-    mod.rs           # Backend trait (async_trait)
-    detector.rs      # runtime backend selection
-    libei.rs         # RemoteDesktop portal + reis
-    wlroots.rs       # virtual-keyboard/pointer + foreign-toplevel + wl_output
-    kde.rs           # libei input + KWin-scripting window ops via D-Bus
-    uinput.rs        # /dev/uinput fallback
-    stub.rs          # PendingBackend placeholder
+wdotool-core/        # library: the engine other Rust code can use
+  src/
+    lib.rs           # public API re-exports
+    backend/
+      mod.rs         # Backend trait (async_trait)
+      detector.rs    # runtime backend selection
+      libei.rs       # RemoteDesktop portal + reis
+      wlroots.rs     # virtual-keyboard/pointer + foreign-toplevel + wl_output
+      kde.rs         # libei input + KWin-scripting window ops via D-Bus
+      gnome.rs       # libei input + GNOME Shell extension D-Bus bridge
+      uinput.rs      # /dev/uinput fallback
+    types.rs         # Capabilities, KeyDirection, MouseButton, WindowInfo
+    error.rs         # WdoError, Result
+    keysym.rs        # ctrl+shift+a parser
+    portal_token.rs  # libei restore_token cache (no more consent spam)
+
+wdotool/             # binary: the CLI
+  src/
+    main.rs          # tokio entrypoint
+    cli.rs           # clap subcommand definitions
+    diag.rs          # `wdotool diag` (env + backend availability)
 ```
 
-Every real backend runs on a dedicated OS thread because the underlying event streams (`reis::EiConvertEventStream`, `wayland_client::EventQueue`) aren't `Send`. Input ops are dispatched to those threads via channels.
+Every real backend runs on a dedicated OS thread because the underlying event streams (`reis::EiConvertEventStream`, `wayland_client::EventQueue`) are not `Send`. Input ops dispatch to those threads via channels.
 
 See [`CHANGELOG.md`](CHANGELOG.md) for release notes.
 
 ## Contributing
 
-Pull requests and issue reports welcome. Two open issues specifically want outside help:
+Pull requests and issue reports welcome. Two open issues specifically want outside help, both about verifying backends on real desktops since the project is maintained from Hyprland:
 
-- [#1](https://github.com/cushycush/wdotool/issues/1) — `help wanted`, `kde`, `needs-testing`. The KDE backend is implemented but has never been exercised against an actual Plasma session (project is maintained from Hyprland). Running `wdotool --backend kde info` on Plasma 5 or 6 and reporting the result would meaningfully de-risk the backend.
-- [#2](https://github.com/cushycush/wdotool/issues/2) — `help wanted`, `gnome`, `enhancement`. GNOME window management needs a Shell extension; the Rust side follows the KDE pattern once the extension exists. Happy to pair on the design or review PRs.
+- [#1](https://github.com/cushycush/wdotool/issues/1) `help wanted`, `kde`, `needs-testing`. The KDE backend is implemented but has never been exercised against an actual Plasma session. Running `wdotool --backend kde info` on Plasma 5 or 6 and posting the output (or a `wdotool diag --copy` paste) would meaningfully de-risk the backend.
+- [#2](https://github.com/cushycush/wdotool/issues/2) `help wanted`, `gnome`, `needs-testing`. The GNOME backend is fully shipped, including the companion Shell extension at `packaging/gnome-extension/wdotool@wdotool.github.io/`. What's missing is real-session smoke testing on GNOME 46+. Install the extension, run a few `wdotool` commands, and post the result.
 
 For other bugs or features, open an issue first for anything non-trivial so the shape can be agreed before code lands.
 

--- a/wdotool/Cargo.toml
+++ b/wdotool/Cargo.toml
@@ -19,5 +19,7 @@ path = "src/main.rs"
 wdotool-core = { path = "../wdotool-core", version = "0.1.6" }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/wdotool/src/cli.rs
+++ b/wdotool/src/cli.rs
@@ -101,4 +101,19 @@ pub enum Command {
 
     /// Show detected environment and backend capabilities.
     Info,
+
+    /// Print an environment + backend availability report. Use this
+    /// when a wdotool command isn't behaving the way you expect; the
+    /// output names the missing piece (portal? group? extension?) and
+    /// prints the fix command. Pass `--copy` to send the report to
+    /// the clipboard, `--json` for machine-readable output.
+    Diag {
+        /// Emit machine-readable JSON instead of markdown.
+        #[arg(long)]
+        json: bool,
+        /// Copy the markdown report to the clipboard via wl-copy
+        /// (falls back to xclip).
+        #[arg(long)]
+        copy: bool,
+    },
 }

--- a/wdotool/src/diag.rs
+++ b/wdotool/src/diag.rs
@@ -1,0 +1,564 @@
+//! `wdotool diag` — environment + backend availability report.
+//!
+//! Probes pre-conditions only. Never opens a portal session, so it will
+//! not trigger a consent dialog. Output is markdown by default; pass
+//! `--json` for a machine-readable shape, `--copy` to send the markdown
+//! through `wl-copy` (or `xclip`).
+//!
+//! The point: when something doesn't work, the user runs `wdotool diag
+//! --copy` and pastes the output into a bug report. No more guessing
+//! whether the portal is missing, the user is in the wrong group, or
+//! the GNOME extension is uninstalled.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::Serialize;
+
+use wdotool_core::detector::Environment;
+
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagFormat {
+    Markdown,
+    Json,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DiagReport {
+    schema_version: u32,
+    wdotool_version: &'static str,
+    environment: EnvSection,
+    backends: Vec<BackendSection>,
+    suggested_fixes: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EnvSection {
+    desktop: Option<String>,
+    session_type: Option<String>,
+    wayland_display: Option<String>,
+    display: Option<String>,
+    compositor_hints: Vec<&'static str>,
+    portal_token_cache_path: Option<String>,
+    portal_token_cached: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BackendSection {
+    name: &'static str,
+    status: BackendStatus,
+    detail: String,
+    fix_hint: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum BackendStatus {
+    Available,
+    Unavailable,
+    Warning,
+}
+
+pub fn run(format: DiagFormat, copy: bool) -> anyhow::Result<()> {
+    let report = build_report();
+    let markdown = render_markdown(&report);
+    let output = match format {
+        DiagFormat::Markdown => markdown.clone(),
+        DiagFormat::Json => serde_json::to_string_pretty(&report)?,
+    };
+
+    if copy {
+        // --copy always pipes the markdown body, regardless of --json.
+        // The markdown is what a human pastes into a bug report.
+        match try_clipboard(&markdown) {
+            Ok(tool) => {
+                eprintln!("Copied diag output to clipboard via {tool}.");
+                if format == DiagFormat::Json {
+                    // User asked for both --json and --copy; print JSON to
+                    // stdout so scripts still see it.
+                    println!("{output}");
+                }
+            }
+            Err(err) => {
+                eprintln!("(no clipboard tool available: {err}; printing to stdout)");
+                println!("{output}");
+            }
+        }
+    } else {
+        println!("{output}");
+    }
+    Ok(())
+}
+
+fn build_report() -> DiagReport {
+    let env = Environment::detect();
+    let cache_path = portal_token_cache_path();
+    let portal_token_cached = cache_path.as_ref().is_some_and(|p| Path::new(p).exists());
+
+    let backends = vec![
+        probe_libei(&env),
+        probe_wlroots(&env),
+        probe_kde(&env),
+        probe_gnome(&env),
+        probe_uinput(),
+    ];
+
+    let suggested_fixes = backends
+        .iter()
+        .filter_map(|b| b.fix_hint.as_ref().map(|h| format!("[{}] {}", b.name, h)))
+        .collect();
+
+    DiagReport {
+        schema_version: SCHEMA_VERSION,
+        wdotool_version: env!("CARGO_PKG_VERSION"),
+        environment: EnvSection {
+            desktop: env.desktop.clone(),
+            session_type: env.session_type.clone(),
+            wayland_display: env.wayland_display.clone(),
+            display: std::env::var("DISPLAY").ok(),
+            compositor_hints: env.compositor_hints.clone(),
+            portal_token_cache_path: cache_path.map(|p| p.display().to_string()),
+            portal_token_cached,
+        },
+        backends,
+        suggested_fixes,
+    }
+}
+
+// ---- backend probes --------------------------------------------------
+
+fn probe_libei(env: &Environment) -> BackendSection {
+    match check_portal_remote_desktop() {
+        PortalCheck::Found => BackendSection {
+            name: "libei",
+            status: BackendStatus::Available,
+            detail: "portal RemoteDesktop interface is exposed".into(),
+            fix_hint: None,
+        },
+        PortalCheck::PortalMissingRemoteDesktop => BackendSection {
+            name: "libei",
+            status: BackendStatus::Unavailable,
+            detail: "xdg-desktop-portal is running but does not expose org.freedesktop.portal.RemoteDesktop".into(),
+            fix_hint: Some(suggest_portal_install(env)),
+        },
+        PortalCheck::PortalNotRunning => BackendSection {
+            name: "libei",
+            status: BackendStatus::Unavailable,
+            detail: "xdg-desktop-portal is not running on the session bus".into(),
+            fix_hint: Some(format!(
+                "install + start xdg-desktop-portal and {}",
+                suggest_portal_install(env)
+            )),
+        },
+        PortalCheck::Error(msg) => BackendSection {
+            name: "libei",
+            status: BackendStatus::Warning,
+            detail: format!("could not probe the portal: {msg}"),
+            fix_hint: Some(
+                "install systemd's `busctl` or set $DBUS_SESSION_BUS_ADDRESS so the probe can reach the session bus".into(),
+            ),
+        },
+    }
+}
+
+fn probe_wlroots(env: &Environment) -> BackendSection {
+    // Probing the actual wl_registry globals would need wayland-client,
+    // which lives behind wdotool-core's wlroots feature and is not part
+    // of the CLI's public API surface. Inferring from compositor hints
+    // is good enough for diag — the wlroots backend's own bootstrap
+    // surfaces a precise error if the protocols aren't there.
+    let is_wlroots = env.has_hint("sway")
+        || env.has_hint("hyprland")
+        || env.has_hint("wayfire")
+        || env.desktop_is("sway")
+        || env.desktop_is("Hyprland");
+    if is_wlroots {
+        BackendSection {
+            name: "wlroots",
+            status: BackendStatus::Available,
+            detail: format!(
+                "wlroots-flavored compositor detected: {:?}",
+                env.compositor_hints
+            ),
+            fix_hint: None,
+        }
+    } else {
+        BackendSection {
+            name: "wlroots",
+            status: BackendStatus::Unavailable,
+            detail: "no Sway / Hyprland / river / Wayfire markers in the environment".into(),
+            fix_hint: None,
+        }
+    }
+}
+
+fn probe_kde(env: &Environment) -> BackendSection {
+    if env.desktop_is("KDE") {
+        BackendSection {
+            name: "kde",
+            status: BackendStatus::Available,
+            detail: "XDG_CURRENT_DESKTOP=KDE; window mgmt via KWin scripting D-Bus".into(),
+            fix_hint: None,
+        }
+    } else {
+        BackendSection {
+            name: "kde",
+            status: BackendStatus::Unavailable,
+            detail: format!("XDG_CURRENT_DESKTOP={}", display_opt(&env.desktop)),
+            fix_hint: None,
+        }
+    }
+}
+
+fn probe_gnome(env: &Environment) -> BackendSection {
+    let extension_path = home_dir().map(|h| {
+        h.join(".local/share/gnome-shell/extensions/wdotool@wdotool.github.io/metadata.json")
+    });
+    probe_gnome_with(env, extension_path.as_deref())
+}
+
+fn probe_gnome_with(env: &Environment, extension_metadata: Option<&Path>) -> BackendSection {
+    let extension_installed = extension_metadata.map(|p| p.exists()).unwrap_or(false);
+
+    match (env.desktop_is("GNOME"), extension_installed) {
+        (true, true) => BackendSection {
+            name: "gnome",
+            status: BackendStatus::Available,
+            detail: "GNOME detected; wdotool@wdotool.github.io extension installed".into(),
+            fix_hint: None,
+        },
+        (true, false) => BackendSection {
+            name: "gnome",
+            status: BackendStatus::Warning,
+            detail: "GNOME detected but the wdotool shell extension is not installed; window management will fall back to bare libei (input only)".into(),
+            fix_hint: Some(
+                "cp -r packaging/gnome-extension/wdotool@wdotool.github.io ~/.local/share/gnome-shell/extensions/ && log out + back in && gnome-extensions enable wdotool@wdotool.github.io".into(),
+            ),
+        },
+        (false, _) => BackendSection {
+            name: "gnome",
+            status: BackendStatus::Unavailable,
+            detail: format!("XDG_CURRENT_DESKTOP={}", display_opt(&env.desktop)),
+            fix_hint: None,
+        },
+    }
+}
+
+fn probe_uinput() -> BackendSection {
+    let path = Path::new("/dev/uinput");
+    if !path.exists() {
+        return BackendSection {
+            name: "uinput",
+            status: BackendStatus::Unavailable,
+            detail: "/dev/uinput does not exist".into(),
+            fix_hint: Some("load the uinput kernel module: sudo modprobe uinput (or rebuild your kernel with CONFIG_INPUT_UINPUT=m)".into()),
+        };
+    }
+    match fs::OpenOptions::new().write(true).open(path) {
+        Ok(_) => BackendSection {
+            name: "uinput",
+            status: BackendStatus::Available,
+            detail: "/dev/uinput is writable by the current user".into(),
+            fix_hint: None,
+        },
+        Err(_) => BackendSection {
+            name: "uinput",
+            status: BackendStatus::Warning,
+            detail: "/dev/uinput exists but the current user cannot open it for writing".into(),
+            fix_hint: Some(
+                "sudo usermod -aG uinput $USER (or `input` on some distros), then log out + back in. A udev rule may also be needed: `KERNEL==\"uinput\", GROUP=\"uinput\", MODE=\"0660\"`".into(),
+            ),
+        },
+    }
+}
+
+// ---- helpers ---------------------------------------------------------
+
+#[derive(Debug)]
+enum PortalCheck {
+    Found,
+    PortalMissingRemoteDesktop,
+    PortalNotRunning,
+    Error(String),
+}
+
+fn check_portal_remote_desktop() -> PortalCheck {
+    let output = match Command::new("busctl")
+        .args([
+            "--user",
+            "introspect",
+            "org.freedesktop.portal.Desktop",
+            "/org/freedesktop/portal/desktop",
+        ])
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => return PortalCheck::Error(format!("could not run busctl: {e}")),
+    };
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("Could not activate") || stderr.contains("not provided by any service") {
+            return PortalCheck::PortalNotRunning;
+        }
+        return PortalCheck::Error(format!(
+            "busctl exited with status {} (stderr: {})",
+            output.status,
+            stderr.trim()
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if stdout.contains("org.freedesktop.portal.RemoteDesktop") {
+        PortalCheck::Found
+    } else {
+        PortalCheck::PortalMissingRemoteDesktop
+    }
+}
+
+fn suggest_portal_install(env: &Environment) -> String {
+    if env.desktop_is("GNOME") {
+        "install xdg-desktop-portal-gnome".into()
+    } else if env.desktop_is("KDE") {
+        "install xdg-desktop-portal-kde".into()
+    } else if env.has_hint("hyprland") {
+        "xdg-desktop-portal-hyprland 1.3.x does not expose RemoteDesktop yet; pass --backend wlroots to use the virtual-keyboard / virtual-pointer protocols directly".into()
+    } else {
+        "install an xdg-desktop-portal backend that exposes RemoteDesktop (xdg-desktop-portal-gnome or xdg-desktop-portal-kde)".into()
+    }
+}
+
+fn portal_token_cache_path() -> Option<PathBuf> {
+    if let Some(state) = std::env::var_os("XDG_STATE_HOME") {
+        let p = PathBuf::from(state);
+        if p.is_absolute() {
+            return Some(p.join("wdotool").join("portal.token"));
+        }
+    }
+    home_dir().map(|h| h.join(".local/state/wdotool/portal.token"))
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+fn display_opt(opt: &Option<String>) -> String {
+    opt.clone().unwrap_or_else(|| "(unset)".into())
+}
+
+fn try_clipboard(content: &str) -> std::result::Result<&'static str, String> {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    for tool in ["wl-copy", "xclip"] {
+        let mut cmd = Command::new(tool);
+        if tool == "xclip" {
+            cmd.args(["-selection", "clipboard"]);
+        }
+        let child = cmd
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn();
+        let mut child = match child {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        if let Some(stdin) = child.stdin.as_mut() {
+            if stdin.write_all(content.as_bytes()).is_err() {
+                let _ = child.kill();
+                continue;
+            }
+        }
+        match child.wait() {
+            Ok(status) if status.success() => return Ok(tool),
+            _ => continue,
+        }
+    }
+    Err("neither wl-copy nor xclip is on $PATH".into())
+}
+
+// ---- markdown rendering ---------------------------------------------
+
+fn render_markdown(r: &DiagReport) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "# wdotool diag (wdotool {})\n\n",
+        r.wdotool_version
+    ));
+
+    // Environment
+    out.push_str("## Environment\n");
+    out.push_str(&format!(
+        "- Desktop: {}\n- Session: {}\n- Wayland display: {}\n- X11 display: {}\n- Compositor hints: {}\n",
+        display_opt(&r.environment.desktop),
+        display_opt(&r.environment.session_type),
+        display_opt(&r.environment.wayland_display),
+        display_opt(&r.environment.display),
+        if r.environment.compositor_hints.is_empty() {
+            "(none)".to_string()
+        } else {
+            r.environment.compositor_hints.join(", ")
+        },
+    ));
+    if let Some(p) = &r.environment.portal_token_cache_path {
+        let mark = if r.environment.portal_token_cached {
+            "cached"
+        } else {
+            "not yet cached"
+        };
+        out.push_str(&format!("- Portal token cache: `{p}` ({mark})\n"));
+    }
+    out.push('\n');
+
+    // Backends
+    out.push_str("## Backends\n");
+    for b in &r.backends {
+        let mark = match b.status {
+            BackendStatus::Available => "available",
+            BackendStatus::Unavailable => "unavailable",
+            BackendStatus::Warning => "warning",
+        };
+        out.push_str(&format!("- **{}** ({mark}): {}\n", b.name, b.detail));
+    }
+    out.push('\n');
+
+    // Suggested fixes
+    if !r.suggested_fixes.is_empty() {
+        out.push_str("## Suggested fixes\n");
+        for fix in &r.suggested_fixes {
+            out.push_str(&format!("- {fix}\n"));
+        }
+        out.push('\n');
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_env() -> Environment {
+        Environment {
+            desktop: None,
+            session_type: None,
+            wayland_display: None,
+            compositor_hints: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn probe_wlroots_says_available_on_hyprland() {
+        let env = Environment {
+            desktop: Some("Hyprland".into()),
+            compositor_hints: vec!["hyprland"],
+            ..empty_env()
+        };
+        let report = probe_wlroots(&env);
+        assert_eq!(report.status, BackendStatus::Available);
+    }
+
+    #[test]
+    fn probe_wlroots_says_unavailable_on_gnome() {
+        let env = Environment {
+            desktop: Some("GNOME".into()),
+            ..empty_env()
+        };
+        let report = probe_wlroots(&env);
+        assert_eq!(report.status, BackendStatus::Unavailable);
+    }
+
+    #[test]
+    fn probe_kde_keys_off_xdg_current_desktop() {
+        let env = Environment {
+            desktop: Some("KDE".into()),
+            ..empty_env()
+        };
+        assert_eq!(probe_kde(&env).status, BackendStatus::Available);
+
+        let env = Environment {
+            desktop: Some("GNOME".into()),
+            ..empty_env()
+        };
+        assert_eq!(probe_kde(&env).status, BackendStatus::Unavailable);
+    }
+
+    #[test]
+    fn probe_gnome_warns_when_extension_missing_but_desktop_is_gnome() {
+        let env = Environment {
+            desktop: Some("GNOME".into()),
+            ..empty_env()
+        };
+        let nonexistent = Path::new("/nonexistent/wdotool-test/metadata.json");
+        let report = probe_gnome_with(&env, Some(nonexistent));
+        assert_eq!(report.status, BackendStatus::Warning);
+        assert!(report.fix_hint.is_some());
+    }
+
+    #[test]
+    fn probe_gnome_unavailable_when_desktop_is_not_gnome() {
+        let env = Environment {
+            desktop: Some("KDE".into()),
+            ..empty_env()
+        };
+        // Extension presence is irrelevant when desktop != GNOME.
+        let report = probe_gnome_with(&env, None);
+        assert_eq!(report.status, BackendStatus::Unavailable);
+    }
+
+    #[test]
+    fn render_markdown_includes_all_sections() {
+        let report = DiagReport {
+            schema_version: 1,
+            wdotool_version: "0.1.6",
+            environment: EnvSection {
+                desktop: Some("GNOME".into()),
+                session_type: Some("wayland".into()),
+                wayland_display: Some("wayland-0".into()),
+                display: None,
+                compositor_hints: vec!["gnome-shell"],
+                portal_token_cache_path: Some("/home/u/.local/state/wdotool/portal.token".into()),
+                portal_token_cached: true,
+            },
+            backends: vec![BackendSection {
+                name: "libei",
+                status: BackendStatus::Available,
+                detail: "portal ok".into(),
+                fix_hint: None,
+            }],
+            suggested_fixes: vec!["[uinput] fix me".into()],
+        };
+        let md = render_markdown(&report);
+        assert!(md.starts_with("# wdotool diag"));
+        assert!(md.contains("## Environment"));
+        assert!(md.contains("## Backends"));
+        assert!(md.contains("## Suggested fixes"));
+        assert!(md.contains("portal.token"));
+        assert!(md.contains("[uinput] fix me"));
+    }
+
+    #[test]
+    fn json_render_round_trips_through_serde() {
+        let report = DiagReport {
+            schema_version: 1,
+            wdotool_version: "0.1.6",
+            environment: EnvSection {
+                desktop: None,
+                session_type: None,
+                wayland_display: None,
+                display: None,
+                compositor_hints: vec![],
+                portal_token_cache_path: None,
+                portal_token_cached: false,
+            },
+            backends: vec![],
+            suggested_fixes: vec![],
+        };
+        let json = serde_json::to_string(&report).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["schema_version"], 1);
+        assert_eq!(value["environment"]["portal_token_cached"], false);
+    }
+}

--- a/wdotool/src/diag.rs
+++ b/wdotool/src/diag.rs
@@ -1,4 +1,4 @@
-//! `wdotool diag` — environment + backend availability report.
+//! `wdotool diag`: environment + backend availability report.
 //!
 //! Probes pre-conditions only. Never opens a portal session, so it will
 //! not trigger a consent dialog. Output is markdown by default; pass
@@ -168,7 +168,7 @@ fn probe_wlroots(env: &Environment) -> BackendSection {
     // Probing the actual wl_registry globals would need wayland-client,
     // which lives behind wdotool-core's wlroots feature and is not part
     // of the CLI's public API surface. Inferring from compositor hints
-    // is good enough for diag — the wlroots backend's own bootstrap
+    // is good enough for diag; the wlroots backend's own bootstrap
     // surfaces a precise error if the protocols aren't there.
     let is_wlroots = env.has_hint("sway")
         || env.has_hint("hyprland")

--- a/wdotool/src/main.rs
+++ b/wdotool/src/main.rs
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Diag has to short-circuit before detector::build so the probes
     // never touch the portal session (which would pop a consent dialog
-    // for libei users — exactly the surprise diag is meant to remove).
+    // for libei users, exactly the surprise diag is meant to remove).
     if let Command::Diag { json, copy } = cli.command {
         let format = if json {
             diag::DiagFormat::Json

--- a/wdotool/src/main.rs
+++ b/wdotool/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod diag;
 
 use std::time::Duration;
 
@@ -15,6 +16,18 @@ use cli::{Cli, Command};
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     init_tracing(cli.verbose);
+
+    // Diag has to short-circuit before detector::build so the probes
+    // never touch the portal session (which would pop a consent dialog
+    // for libei users — exactly the surprise diag is meant to remove).
+    if let Command::Diag { json, copy } = cli.command {
+        let format = if json {
+            diag::DiagFormat::Json
+        } else {
+            diag::DiagFormat::Markdown
+        };
+        return diag::run(format, copy);
+    }
 
     let env = Environment::detect();
 
@@ -134,6 +147,11 @@ async fn dispatch(backend: &dyn Backend, env: &Environment, cmd: Command) -> Res
         },
         Command::Windowactivate { id } => backend.activate_window(&WindowId(id)).await?,
         Command::Windowclose { id } => backend.close_window(&WindowId(id)).await?,
+        Command::Diag { .. } => {
+            // Handled in main() before dispatch is called so diag never
+            // bootstraps a backend.
+            unreachable!("Diag short-circuits before dispatch");
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
When something doesn't work with wdotool, users currently have to guess: is the portal missing, am I in the wrong group, is the GNOME extension actually installed, did my compositor restart eat my token. This PR adds a diagnostic command that answers those questions, and fixes the README so it stops claiming things that aren't true anymore.

`wdotool diag` prints a structured report: the environment (XDG vars, compositor hints, X11 display, portal token cache state), each backend's availability with a precise reason and a one-line fix hint, and a suggested-fixes list at the bottom that deduplicates across backends. `wdotool diag --copy` pipes the markdown through wl-copy (falling back to xclip), so the trip from "this is broken" to "paste this into a bug report" is one command.

The probes are pre-condition checks only. None of them open a portal session. That's deliberate: diag is what users will reach for when a consent flow already went sideways, and popping another consent dialog would defeat the whole point.

Live on Hyprland it correctly reports libei unavailable (xdg-desktop-portal-hyprland 1.3.x doesn't expose RemoteDesktop yet), wlroots available, kde and gnome unavailable for the obvious reason, uinput writable, and points the user at `--backend wlroots` as the fix.

The second commit fixes the README. It was several PRs out of date. The project layout section still showed a single-crate src/ tree, even though main is a workspace now. The libei backend section didn't mention the portal token cache, so a reader would assume every command pops a consent dialog forever. The GNOME backend section read like the Shell extension was still being designed, when in fact it shipped in v0.1.6 and lives in `packaging/gnome-extension/`. There was no mention of `wdotool diag` in the usage examples. And there was no documentation at all on using wdotool-core as a library, despite that being the whole point of the workspace split. All fixed.

CHANGELOG also gets an Unreleased section covering the workspace split, per-backend Cargo features, the boxed WdoError shape, the portal token cache, the MSRV bump, and the new diag command.

This covers item 4 of v0.2.0 plus the load-bearing parts of item 7. The full README rewrite to "wflow substrate" framing (still item 7) is a separate piece of work; this PR just stops the README from lying about the current state.