### PR TITLE
feat: capabilities report (schema v1) + wdotool capabilities

### DIFF
--- a/docs/capabilities-schema.json
+++ b/docs/capabilities-schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://wdotool.dev/schemas/capabilities/v1.json",
+  "title": "wdotool capabilities report v1",
+  "description": "Output shape for `wdotool capabilities` and the public `wdotool_core::capabilities_report()` API. Forward-compat rules: schema_version=1 is the contract for this file; adding new optional fields to objects is backward-compatible (consumers MUST ignore unknown fields); removing or renaming fields, narrowing types, or changing enum semantics requires bumping schema_version and shipping a new schema file (capabilities/v2.json) plus an adapter.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "wdotool_version",
+    "backend",
+    "input",
+    "window",
+    "extras",
+    "platform"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Locked at 1 for this schema file. Future incompatible shapes ship as v2.json."
+    },
+    "wdotool_version": {
+      "type": "string",
+      "description": "Cargo package version of the running wdotool binary or wdotool-core consumer (e.g. `0.2.0`)."
+    },
+    "backend": {
+      "type": "object",
+      "required": ["selected", "kind", "delegated_to", "fallback_chain"],
+      "properties": {
+        "selected": {
+          "type": "string",
+          "description": "Name of the backend currently in use. One of: libei, wlroots, kde, gnome, uinput. New backends added in future versions extend this list (open enum)."
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["direct", "daemon"],
+          "description": "How the backend was constructed. `direct` means the consumer drives the backend in-process. `daemon` means a long-lived `wdotool daemon` process holds the libei session and clients RPC into it. v0.2.0 only emits `direct`; `daemon` is reserved for v0.4.0+."
+        },
+        "delegated_to": {
+          "type": ["string", "null"],
+          "description": "When `kind=daemon`, names the underlying backend the daemon delegates to (e.g. `libei`). Always null when `kind=direct`."
+        },
+        "fallback_chain": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Ordered list of backend names the detector would try, given the current environment. Diagnostic only; clients should not assume this list is exhaustive."
+        }
+      }
+    },
+    "input": {
+      "type": "object",
+      "required": [
+        "key",
+        "type_text",
+        "type_unicode",
+        "mouse_move_absolute",
+        "mouse_move_relative",
+        "mouse_button",
+        "scroll",
+        "modifiers"
+      ],
+      "properties": {
+        "key": { "type": "boolean" },
+        "type_text": { "type": "boolean" },
+        "type_unicode": {
+          "type": "string",
+          "enum": ["full", "bmp_only", "ascii_only", "none"],
+          "description": "How well `type` handles non-ASCII text. `full` = arbitrary Unicode including astral plane (wlroots via transient keymap). `bmp_only` = Basic Multilingual Plane characters work, astral chars (e.g. emoji) are dropped. `ascii_only` = only ASCII works; non-ASCII chars are skipped with a warning (libei / kde / gnome / uinput, since the keymap is owned by the EIS server or the kernel). `none` = no text input."
+        },
+        "mouse_move_absolute": { "type": "boolean" },
+        "mouse_move_relative": { "type": "boolean" },
+        "mouse_button": { "type": "boolean" },
+        "scroll": { "type": "boolean" },
+        "modifiers": {
+          "type": "string",
+          "enum": ["send-only"],
+          "description": "Whether the backend can read the compositor's current modifier state. `send-only` is the only value v0.2.0 emits: Wayland's security model does not expose modifier reads to clients, so `--clearmodifiers` does an unconditional release rather than xdotool's save-and-restore. Future enum values may be added if a backend gains read access."
+        }
+      }
+    },
+    "window": {
+      "type": "object",
+      "required": ["list", "active", "activate", "close", "match_by"],
+      "properties": {
+        "list": { "type": "boolean" },
+        "active": { "type": "boolean" },
+        "activate": { "type": "boolean" },
+        "close": { "type": "boolean" },
+        "match_by": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["title", "app_id", "pid", "class"]
+          },
+          "uniqueItems": true,
+          "description": "Which window attributes the backend can match on for `wdotool search`. v0.2.0 emits `[\"title\"]` everywhere (only matcher implemented). The element enum is closed: removing or renaming a value bumps schema_version. Adding values to a backend's array is backward-compat."
+        }
+      }
+    },
+    "extras": {
+      "type": "object",
+      "required": ["diag", "outputs", "record", "json_output"],
+      "properties": {
+        "diag": {
+          "type": "boolean",
+          "description": "`wdotool diag` is available."
+        },
+        "outputs": {
+          "type": "boolean",
+          "description": "`wdotool outputs --json` is available + `mousemove --output` works. v0.2.0 always false; planned for v0.4.0+."
+        },
+        "record": {
+          "type": "object",
+          "required": ["supported", "source"],
+          "properties": {
+            "supported": { "type": "boolean" },
+            "source": {
+              "type": ["string", "null"],
+              "enum": ["libei-receiver", null],
+              "description": "Where the recorder sources events. Locked enum; v0.2.0 always null. v0.4.0+ may emit `libei-receiver`."
+            }
+          },
+          "description": "`wdotool record` capability. Stub in v0.2.0 (always {supported: false, source: null})."
+        },
+        "json_output": {
+          "type": "boolean",
+          "description": "Whether commands accept `--json` for structured output. v0.2.0: true (diag and capabilities support it)."
+        }
+      }
+    },
+    "platform": {
+      "type": "object",
+      "required": ["desktop", "session_type", "compositor_hints"],
+      "properties": {
+        "desktop": {
+          "type": ["string", "null"],
+          "description": "Value of `XDG_CURRENT_DESKTOP`, or null when unset."
+        },
+        "session_type": {
+          "type": ["string", "null"],
+          "description": "Value of `XDG_SESSION_TYPE`, or null when unset."
+        },
+        "compositor_hints": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Detected compositor markers from environment variables. Open enum; v0.2.0 emits subsets of [\"sway\", \"hyprland\", \"wayfire\"]. Future hints may be added."
+        }
+      }
+    }
+  }
+}

--- a/wdotool-core/Cargo.toml
+++ b/wdotool-core/Cargo.toml
@@ -18,8 +18,6 @@ libei = [
     "dep:enumflags2",
     "dep:futures-util",
     "dep:reis",
-    "dep:serde",
-    "dep:serde_json",
     "dep:xkbcommon",
 ]
 wlroots = [
@@ -31,13 +29,17 @@ wlroots = [
     "dep:xkbcommon",
     "dep:xkeysym",
 ]
-kde = ["libei", "dep:zbus", "dep:serde", "dep:serde_json"]
-gnome = ["libei", "dep:zbus", "dep:serde", "dep:serde_json"]
+kde = ["libei", "dep:zbus"]
+gnome = ["libei", "dep:zbus"]
 uinput = ["dep:input-linux", "dep:libc", "dep:xkbcommon"]
 
 [dependencies]
-# Always-on (used across all backends or by core abstractions)
+# Always-on. serde + serde_json are always-on because the public
+# capabilities module emits a versioned JSON schema that consumers
+# rely on regardless of which backends are compiled in.
 async-trait = "0.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync", "time"] }
 tracing = "0.1"
@@ -50,8 +52,6 @@ input-linux = { version = "0.7", optional = true }
 libc = { version = "0.2", optional = true }
 reis = { version = "0.6", features = ["tokio"], optional = true }
 rustix = { version = "1", features = ["fs"], optional = true }
-serde = { version = "1", features = ["derive"], optional = true }
-serde_json = { version = "1", optional = true }
 wayland-client = { version = "0.31", optional = true }
 wayland-protocols = { version = "0.32", features = ["client"], optional = true }
 wayland-protocols-misc = { version = "0.3", features = ["client"], optional = true }

--- a/wdotool-core/src/capabilities.rs
+++ b/wdotool-core/src/capabilities.rs
@@ -1,0 +1,374 @@
+//! Capabilities report: what does this wdotool installation support?
+//!
+//! This module is the canonical exit point for "tell me about this
+//! wdotool" data. The shape is locked by the JSON Schema at
+//! `docs/capabilities-schema.json` and the rules baked in there:
+//! `schema_version` is `1` for this file; adding new fields is
+//! backward-compat (consumers must ignore unknown fields); removing,
+//! renaming, or narrowing types requires a `schema_version` bump and
+//! a separate `capabilities/v2.json` schema file.
+//!
+//! Public entry points:
+//! - [`report`] returns a typed [`CapabilitiesReport`] for callers
+//!   that want struct access.
+//! - [`report_json`] returns the same shape as a `serde_json::Value`,
+//!   matching the eng plan's `Capabilities::to_schema_v1() -> Value`
+//!   contract. wflows.com and other JSON consumers go through this.
+
+use serde::{Deserialize, Serialize};
+
+use crate::backend::Backend;
+use crate::detector::{priority, BackendKind, Environment};
+use crate::types::Capabilities;
+
+/// Locked at 1 for this schema. See `docs/capabilities-schema.json`.
+pub const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapabilitiesReport {
+    pub schema_version: u32,
+    pub wdotool_version: String,
+    pub backend: BackendInfo,
+    pub input: InputCaps,
+    pub window: WindowCaps,
+    pub extras: Extras,
+    pub platform: PlatformInfo,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackendInfo {
+    pub selected: String,
+    pub kind: BackendKindLabel,
+    pub delegated_to: Option<String>,
+    pub fallback_chain: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BackendKindLabel {
+    Direct,
+    Daemon,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InputCaps {
+    pub key: bool,
+    pub type_text: bool,
+    pub type_unicode: TypeUnicode,
+    pub mouse_move_absolute: bool,
+    pub mouse_move_relative: bool,
+    pub mouse_button: bool,
+    pub scroll: bool,
+    pub modifiers: ModifiersCap,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TypeUnicode {
+    /// Arbitrary Unicode including the astral plane. Currently only
+    /// the wlroots backend, which uploads a transient xkb keymap.
+    Full,
+    /// Basic Multilingual Plane (BMP) characters work; astral chars
+    /// (e.g. emoji beyond U+FFFF) are dropped.
+    BmpOnly,
+    /// Only ASCII works. Non-ASCII chars are skipped with a warning.
+    /// libei / kde / gnome / uinput sit here because the EIS server
+    /// or the kernel owns the keymap and we cannot install our own.
+    AsciiOnly,
+    /// No `type` support at all.
+    None,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ModifiersCap {
+    /// We can send modifier press/release but cannot read the current
+    /// modifier state from the compositor. Wayland's security model
+    /// does not expose that read; v0.2.0 emits this for every backend.
+    SendOnly,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WindowCaps {
+    pub list: bool,
+    pub active: bool,
+    pub activate: bool,
+    pub close: bool,
+    pub match_by: Vec<MatchBy>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MatchBy {
+    Title,
+    AppId,
+    Pid,
+    Class,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Extras {
+    pub diag: bool,
+    pub outputs: bool,
+    pub record: RecordCaps,
+    pub json_output: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecordCaps {
+    pub supported: bool,
+    pub source: Option<RecordSource>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RecordSource {
+    LibeiReceiver,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlatformInfo {
+    pub desktop: Option<String>,
+    pub session_type: Option<String>,
+    pub compositor_hints: Vec<String>,
+}
+
+/// Build the typed report for the current environment + selected backend.
+pub fn report(env: &Environment, backend: &dyn Backend) -> CapabilitiesReport {
+    let caps: Capabilities = backend.capabilities();
+    let backend_name = backend.name().to_string();
+
+    CapabilitiesReport {
+        schema_version: SCHEMA_VERSION,
+        wdotool_version: env!("CARGO_PKG_VERSION").to_string(),
+        backend: BackendInfo {
+            selected: backend_name.clone(),
+            // v0.2.0 only ships direct-mode backends. Daemon mode is
+            // a v0.4.0+ shape; the schema reserves the enum value so
+            // future consumers can branch cleanly.
+            kind: BackendKindLabel::Direct,
+            delegated_to: None,
+            fallback_chain: priority(env)
+                .into_iter()
+                .map(backend_kind_label)
+                .map(str::to_string)
+                .collect(),
+        },
+        input: InputCaps {
+            key: caps.key_input,
+            type_text: caps.text_input,
+            type_unicode: type_unicode_for(&backend_name),
+            mouse_move_absolute: caps.pointer_move_absolute,
+            mouse_move_relative: caps.pointer_move_relative,
+            mouse_button: caps.pointer_button,
+            scroll: caps.scroll,
+            // Wayland clients cannot read the compositor's current
+            // modifier state. Every backend is send-only in v0.2.0;
+            // the enum is forward-compat for a future read-capable
+            // backend.
+            modifiers: ModifiersCap::SendOnly,
+        },
+        window: WindowCaps {
+            list: caps.list_windows,
+            active: caps.active_window,
+            activate: caps.activate_window,
+            close: caps.close_window,
+            // v0.2.0 only matches by title (`wdotool search --name`).
+            // The `match_by` array can grow without a schema bump
+            // when class / app_id / pid matchers land.
+            match_by: vec![MatchBy::Title],
+        },
+        extras: Extras {
+            diag: true,
+            outputs: false,
+            record: RecordCaps {
+                supported: false,
+                source: None,
+            },
+            // wdotool diag --json + wdotool capabilities both emit
+            // structured output, so the flag is true.
+            json_output: true,
+        },
+        platform: PlatformInfo {
+            desktop: env.desktop.clone(),
+            session_type: env.session_type.clone(),
+            compositor_hints: env
+                .compositor_hints
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect(),
+        },
+    }
+}
+
+/// Same shape as [`report`] but emitted as a `serde_json::Value`.
+/// Matches the `Capabilities::to_schema_v1() -> Value` contract from
+/// the v0.2.0 eng plan; wflows.com and other JSON-only consumers
+/// should use this entry point so we do not commit to the in-memory
+/// Rust type as part of the cross-language API.
+pub fn report_json(env: &Environment, backend: &dyn Backend) -> serde_json::Value {
+    serde_json::to_value(report(env, backend))
+        .expect("CapabilitiesReport derives Serialize and contains no maps with non-string keys")
+}
+
+/// Map a [`BackendKind`] to its canonical string label, matching the
+/// names the schema expects in `backend.fallback_chain`.
+fn backend_kind_label(kind: BackendKind) -> &'static str {
+    match kind {
+        BackendKind::Libei => "libei",
+        BackendKind::Wlroots => "wlroots",
+        BackendKind::KdeDBus => "kde",
+        BackendKind::GnomeExt => "gnome",
+        BackendKind::Uinput => "uinput",
+    }
+}
+
+/// Per-backend Unicode-typing capability. Hardcoded because the
+/// `Capabilities` struct does not carry this info. Real-world testing
+/// on KDE / GNOME may refine these mappings; that refinement bumps
+/// individual values, not the schema_version (the enum is stable).
+fn type_unicode_for(backend_name: &str) -> TypeUnicode {
+    match backend_name {
+        "wlroots" => TypeUnicode::Full,
+        "libei" | "kde" | "gnome" | "uinput" => TypeUnicode::AsciiOnly,
+        _ => TypeUnicode::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::time::Duration;
+
+    use crate::error::Result;
+    use crate::types::{KeyDirection, MouseButton, WindowId, WindowInfo};
+
+    /// Minimal fake backend for capabilities tests. Returns a fixed
+    /// `name` and a fully-on `Capabilities` struct so the report's
+    /// shape can be inspected without booting a real backend.
+    struct FakeBackend {
+        name: &'static str,
+    }
+
+    #[async_trait]
+    impl Backend for FakeBackend {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+        fn capabilities(&self) -> Capabilities {
+            Capabilities {
+                key_input: true,
+                text_input: true,
+                pointer_move_absolute: true,
+                pointer_move_relative: true,
+                pointer_button: true,
+                scroll: true,
+                list_windows: true,
+                active_window: true,
+                activate_window: true,
+                close_window: true,
+            }
+        }
+        async fn key(&self, _: &str, _: KeyDirection) -> Result<()> {
+            unimplemented!()
+        }
+        async fn type_text(&self, _: &str, _: Duration) -> Result<()> {
+            unimplemented!()
+        }
+        async fn mouse_move(&self, _: i32, _: i32, _: bool) -> Result<()> {
+            unimplemented!()
+        }
+        async fn mouse_button(&self, _: MouseButton, _: KeyDirection) -> Result<()> {
+            unimplemented!()
+        }
+        async fn scroll(&self, _: f64, _: f64) -> Result<()> {
+            unimplemented!()
+        }
+        async fn list_windows(&self) -> Result<Vec<WindowInfo>> {
+            unimplemented!()
+        }
+        async fn active_window(&self) -> Result<Option<WindowInfo>> {
+            unimplemented!()
+        }
+        async fn activate_window(&self, _: &WindowId) -> Result<()> {
+            unimplemented!()
+        }
+        async fn close_window(&self, _: &WindowId) -> Result<()> {
+            unimplemented!()
+        }
+    }
+
+    fn fake_env() -> Environment {
+        Environment {
+            desktop: Some("GNOME".into()),
+            session_type: Some("wayland".into()),
+            wayland_display: Some("wayland-0".into()),
+            compositor_hints: vec!["gnome-shell"],
+        }
+    }
+
+    #[test]
+    fn report_shape_matches_schema_v1() {
+        let env = fake_env();
+        let backend = FakeBackend { name: "libei" };
+        let r = report(&env, &backend);
+        assert_eq!(r.schema_version, 1);
+        assert_eq!(r.backend.selected, "libei");
+        assert_eq!(r.backend.kind, BackendKindLabel::Direct);
+        assert!(r.backend.delegated_to.is_none());
+        assert!(!r.backend.fallback_chain.is_empty());
+        assert_eq!(r.input.modifiers, ModifiersCap::SendOnly);
+        assert_eq!(r.window.match_by, vec![MatchBy::Title]);
+        assert!(r.extras.diag);
+        assert!(!r.extras.outputs);
+        assert!(!r.extras.record.supported);
+        assert!(r.extras.record.source.is_none());
+        assert!(r.extras.json_output);
+        assert_eq!(r.platform.desktop.as_deref(), Some("GNOME"));
+    }
+
+    #[test]
+    fn type_unicode_is_full_only_on_wlroots() {
+        assert_eq!(type_unicode_for("wlroots"), TypeUnicode::Full);
+        assert_eq!(type_unicode_for("libei"), TypeUnicode::AsciiOnly);
+        assert_eq!(type_unicode_for("kde"), TypeUnicode::AsciiOnly);
+        assert_eq!(type_unicode_for("gnome"), TypeUnicode::AsciiOnly);
+        assert_eq!(type_unicode_for("uinput"), TypeUnicode::AsciiOnly);
+        // Unknown backends fail closed: caller sees TypeUnicode::None.
+        assert_eq!(type_unicode_for("future-backend"), TypeUnicode::None);
+    }
+
+    #[test]
+    fn report_json_round_trips_through_serde() {
+        let env = fake_env();
+        let backend = FakeBackend { name: "wlroots" };
+        let value = report_json(&env, &backend);
+        // schema_version pins to 1 in the JSON shape.
+        assert_eq!(value["schema_version"], 1);
+        // type_unicode serializes as snake_case "full" for wlroots.
+        assert_eq!(value["input"]["type_unicode"], "full");
+        // Closed enum values come through as their schema strings.
+        assert_eq!(value["backend"]["kind"], "direct");
+        assert_eq!(value["input"]["modifiers"], "send-only");
+        // match_by is an array of snake_case strings.
+        assert_eq!(value["window"]["match_by"], serde_json::json!(["title"]));
+        // record.source is null in v0.2.0.
+        assert!(value["extras"]["record"]["source"].is_null());
+    }
+
+    #[test]
+    fn fallback_chain_uses_canonical_backend_labels() {
+        let env = fake_env();
+        let backend = FakeBackend { name: "gnome" };
+        let r = report(&env, &backend);
+        // Every entry should be one of the five known labels.
+        let known = ["libei", "wlroots", "kde", "gnome", "uinput"];
+        for entry in &r.backend.fallback_chain {
+            assert!(
+                known.contains(&entry.as_str()),
+                "unexpected fallback_chain entry: {entry}"
+            );
+        }
+    }
+}

--- a/wdotool-core/src/lib.rs
+++ b/wdotool-core/src/lib.rs
@@ -10,6 +10,9 @@
 //! - [`WdoError`] / [`Result`]: the error type returned by every fallible
 //!   call.
 //! - [`keysym`]: the chord parser used by the CLI (`ctrl+shift+a` etc.).
+//! - [`capabilities`]: structured capability report (schema v1; see
+//!   `docs/capabilities-schema.json`). Use this to ask "what does
+//!   this wdotool installation support?" from Rust or via JSON.
 //!
 //! Per-backend modules (libei, wlroots, kde, gnome, uinput) are gated
 //! behind Cargo features. Default features enable all five. Downstream
@@ -18,6 +21,7 @@
 //! `default-features = false` + a custom feature list.
 
 pub mod backend;
+pub mod capabilities;
 pub mod error;
 pub mod keysym;
 pub mod types;

--- a/wdotool/src/cli.rs
+++ b/wdotool/src/cli.rs
@@ -102,6 +102,12 @@ pub enum Command {
     /// Show detected environment and backend capabilities.
     Info,
 
+    /// Print a structured capabilities report (schema v1) as JSON.
+    /// This is the machine-readable cousin of `info`. The schema is
+    /// documented at `docs/capabilities-schema.json` and is the
+    /// contract that wflows.com and other downstream tools consume.
+    Capabilities,
+
     /// Print an environment + backend availability report. Use this
     /// when a wdotool command isn't behaving the way you expect; the
     /// output names the missing piece (portal? group? extension?) and

--- a/wdotool/src/main.rs
+++ b/wdotool/src/main.rs
@@ -48,6 +48,14 @@ async fn main() -> anyhow::Result<()> {
 
 async fn dispatch(backend: &dyn Backend, env: &Environment, cmd: Command) -> Result<()> {
     match cmd {
+        Command::Capabilities => {
+            let value = wdotool_core::capabilities::report_json(env, backend);
+            // pretty for humans tailing the output; consumers parse
+            // either form fine.
+            let pretty = serde_json::to_string_pretty(&value)
+                .map_err(|e| WdoError::InvalidArg(format!("capabilities serialization: {e}")))?;
+            println!("{pretty}");
+        }
         Command::Info => {
             let caps = backend.capabilities();
             println!("backend:  {}", backend.name());


### PR DESCRIPTION
Other Rust tools (wflow, wflows.com, future stuff) need a reliable way to ask "what does this wdotool support?" Right now they have to scrape the freeform output of `wdotool info`, or guess from the backend name whether full Unicode typing works, or whether window matching by class is implemented. That's brittle and it gets worse every time wdotool grows.

This PR adds a JSON schema and a `wdotool capabilities` command that prints to it. Run `wdotool capabilities` and you get JSON with five sections (the picked backend, what input ops work, what window ops work, optional extras like diag and record, and platform info). The schema file at `docs/capabilities-schema.json` documents the exact shape. It's locked at version 1, with closed enums where values need to stay stable and open object shapes where new fields can show up later.

On Hyprland, the output looks like this:

```json
{
  "schema_version": 1,
  "backend": { "selected": "wlroots", "fallback_chain": ["wlroots", "libei", "uinput"], ... },
  "input": { "type_unicode": "full", "modifiers": "send-only", ... },
  "window": { "match_by": ["title"], ... },
  "extras": { "diag": true, "record": { "supported": false, "source": null }, ... }
}
```

Two commits. First adds the schema file and a Rust API in wdotool-core (a typed `CapabilitiesReport` struct plus `report_json()` for cross-language consumers). Second wires up the CLI subcommand. Daemon mode and recording are stubs in v0.2.0; the schema reserves the enum values so when those features land later they don't bump the schema version.

One small Cargo cleanup along the way: `serde` and `serde_json` moved from feature-gated (under kde and gnome) to always-on. The capabilities module needs them everywhere. The previous gating only saved a few small crates in builds nobody actually does.

I tested it on Hyprland and ran a manual structural check against the schema (all required fields present, schema_version is 1). fmt clean, clippy clean, all 36 tests pass, every feature subset still compiles.

This is item 5 of v0.2.0. Items 6 (KDE real-hardware verification) and 8 (distribution: Flathub + DEB + RPM) are still ahead.