### PR TITLE
docs: substrate framing in README + honest xdotool compat table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `docs/xdotool-compat.md`. Honest parity table between xdotool and wdotool, grouped by category (input, window actions, window queries, workspace ops, X11-only). Each row marks the command as shipped, partial, deferred, or not planned, with a short reason. Replaces the implicit "drop-in replacement" promise the old README made.
 - DEB and RPM packages for Debian / Ubuntu and Fedora / openSUSE / RHEL families. Built by a new `distros.yml` CI workflow that runs alongside cargo-dist's release on every tag push and uploads both artifacts to the same GitHub Release. Closes the install-friction gap for users on those distros, who previously had to either build from crates.io (requires Rust toolchain) or use the generic shell installer.
 - Flathub manifest, .desktop file, and AppStream metainfo at `packaging/flatpak/`. App ID is `io.github.cushycush.wdotool`. The manifest builds locally; submission to flathub/flathub is a separate manual step the maintainer does. See `packaging/flatpak/README.md` for the steps.
 - `wdotool diag` and `wdotool diag --copy`. Environment + backend availability report meant for bug triage. Probes pre-conditions only (XDG env vars, portal availability via `busctl`, GNOME extension presence, `/dev/uinput` writability, portal token cache state), so the diag run never opens a portal session and never pops a consent dialog. Markdown by default, `--json` for machine-readable output, `--copy` pipes the markdown through `wl-copy` (falling back to `xclip`).
@@ -15,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Per-backend Cargo features (`libei`, `wlroots`, `kde`, `gnome`, `uinput`) on the new `wdotool-core` library crate. Default-on enables all five. Downstream Rust consumers can opt out: `default-features = false, features = ["libei", "wlroots", "kde", "gnome"]` drops uinput's `input-linux` and `libc` deps.
 
 ### Changed
+- README opening reframed. wdotool is no longer described as an "xdotool-compatible CLI"; it's an input automation tool with both a CLI and a library API, and `wflow` is the first known library consumer. The "Why" section now points migrants at a new `docs/xdotool-compat.md` for the honest parity table instead of overpromising drop-in compatibility.
 - Repo is now a Cargo workspace. The engine moved into `wdotool-core/` (a library crate); the `wdotool` binary is a thin clap wrapper that depends on `wdotool-core`. End-user behavior is unchanged. Other Rust projects can `cargo add wdotool-core` and call the engine directly instead of subprocessing the binary.
 - `WdoError::Backend.source` type changed from `anyhow::Error` to `Box<dyn std::error::Error + Send + Sync>`. `wdotool-core` no longer pulls `anyhow` into its dependents.
 - libei's `select_devices` switched from `PersistMode::DoNot` to `PersistMode::ExplicitlyRevoked` so the portal actually issues restore tokens.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/cushycush/wdotool/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/cushycush/wdotool/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg?style=flat-square)](#license)
 
-An xdotool-compatible input automation CLI for Wayland, built on the protocols that were actually designed for this.
+Input automation for Wayland. Send keystrokes, move the mouse, focus and close windows. Works as a command-line tool for shell scripts and ad-hoc use, and as a Rust library (`wdotool-core`) for tools that want to embed it. [wflow](https://github.com/cushycush/wflow) is the first known library consumer.
 
 ## Why
 
-- **xdotool** is X11-only and does not work on Wayland.
-- **ydotool** writes to `/dev/uinput`, which means root (or careful udev rules), no focus awareness, and no window management. It bypasses the compositor entirely, which breaks in sandboxed sessions and loses any security boundary.
-- **wdotool** uses the protocols Wayland already provides for this: libei (via the XDG RemoteDesktop portal), wlroots' virtual-keyboard/pointer, and foreign-toplevel-management. It respects compositor focus and permissions, and only falls back to uinput when nothing better is available.
+If you've been wanting xdotool on Wayland, this is the closest thing. wdotool covers most of the same operations (key, type, mouse, scroll, search, focus) using the protocols Wayland actually provides for this work: libei via the XDG RemoteDesktop portal, wlroots virtual-keyboard and virtual-pointer, KWin scripting on KDE, and a Shell extension on GNOME. It respects compositor focus and permissions; it does not bypass them like ydotool does with `/dev/uinput`.
+
+"Closest thing" is doing real work in that sentence. wdotool is **not** a drop-in xdotool replacement. The CLI surface aims to be argv-compatible for the common commands so existing scripts can port without much editing, but full parity is not promised. See [`docs/xdotool-compat.md`](docs/xdotool-compat.md) for an honest table of what works, what does not, and what is intentionally out of scope.
+
+For comparison with the alternatives: **xdotool** is X11-only and does not work on Wayland at all. **ydotool** writes to `/dev/uinput`, which means root (or carefully tuned udev rules), no focus awareness, and no window management. It bypasses the compositor entirely, which breaks inside sandboxed sessions and loses any security boundary the compositor was enforcing. **wdotool** stays inside the compositor's permission model.
 
 ## Status
 

--- a/docs/xdotool-compat.md
+++ b/docs/xdotool-compat.md
@@ -1,0 +1,104 @@
+# xdotool compatibility
+
+wdotool is **not** a drop-in xdotool replacement.
+
+The CLI surface aims to be argv-compatible for the operations most scripts use, so a `wdotool key ctrl+c` works the same as the xdotool equivalent. Beyond that, the parity gap widens fast: a lot of xdotool's surface depends on X11 concepts that do not exist on Wayland (interactive window pickers, global virtual-desktop manipulation, X11 properties), and a lot of the rest is window-state mutation that the Wayland security model intentionally does not expose to clients.
+
+This page is the honest table. If you are porting a script and the command you want is `🚫 not planned`, you will need to find a non-xdotool way to do that thing.
+
+## Status legend
+
+- ✅ shipped: works today on at least one backend
+- 🧪 partial: implemented but with caveats (limited match types, single-monitor only, etc.)
+- ❌ deferred: would work on Wayland but isn't built yet; will land on demand
+- 🚫 not planned: blocked by Wayland's design or by xdotool semantics that don't translate
+
+## Input
+
+| xdotool command | wdotool | notes |
+| --- | --- | --- |
+| `key`, `keydown`, `keyup` | ✅ | All five backends |
+| `type` | ✅ | Full Unicode on wlroots via transient keymap; ASCII-only fallback elsewhere (the EIS server or the kernel owns the keymap) |
+| `mousemove` | ✅ | Both absolute and relative |
+| `mousemove_relative` | ✅ | `wdotool mousemove --relative` |
+| `click` | ✅ | xdotool indices: 1=left, 2=middle, 3=right, 8=back, 9=forward |
+| `mousedown`, `mouseup` | ✅ |  |
+| `mousewheeldown`, `mousewheelup` | ✅ | Use `wdotool scroll dx dy` |
+| `getmouselocation` | ❌ | Pure send-side surface today; no read of pointer position. Open an issue if you need it |
+
+## Window actions
+
+| xdotool command | wdotool | notes |
+| --- | --- | --- |
+| `windowactivate` | ✅ | wlroots / kde / gnome backends |
+| `windowclose` | ✅ |  |
+| `windowkill` | ✅ | Same as `windowclose` on Wayland |
+| `windowfocus` | ❌ | xdotool distinguishes focus from activate; wdotool currently only activates |
+| `windowmove`, `windowsize` | 🚫 | Wayland clients can't reposition or resize other windows; that's the compositor's job. Talk to your compositor's IPC (sway-msg, hyprctl, kwriteconfig) |
+| `windowmap`, `windowunmap`, `windowminimize`, `windowraise` | 🚫 | Same reason |
+| `windowstate` | 🚫 | Same reason |
+| `windowreparent` | 🚫 | X11 reparenting concept does not exist on Wayland |
+
+## Window queries
+
+| xdotool command | wdotool | notes |
+| --- | --- | --- |
+| `search` | 🧪 | Implemented with `--name` (title regex) and `--class` (substring on app_id). xdotool's `--role`, `--classname`, `--screen`, `--desktop`, `--all`, `--any` are not implemented |
+| `getactivewindow` | ✅ | Returns the focused window's id |
+| `getwindowfocus` | ✅ | Same as `getactivewindow` on Wayland (Wayland does not expose pointer-focus separately from keyboard-focus to clients) |
+| `getwindowname` | ❌ | Use `wdotool search` and parse the output for now |
+| `getwindowpid` | ❌ | Same. The `pid` field is in `WindowInfo` already; just not surfaced in the CLI yet |
+| `getwindowclassname` | ❌ |  |
+| `getwindowgeometry` | ❌ | Compositor-dependent; wlroots can do it through foreign-toplevel, KWin via scripting. Not built yet |
+
+## Selection / interactive UI
+
+| xdotool command | wdotool | notes |
+| --- | --- | --- |
+| `selectwindow` | 🚫 | xdotool's interactive picker is an X11 grab. Wayland's security model doesn't allow grabbing arbitrary windows. Closest equivalent: `slurp` for region picking, or a compositor-specific picker |
+| `behave`, `behave_screen_edge`, `behave_screen_corner` | 🚫 | xdotool's event-callback hooks are X11-specific; the Wayland equivalents are compositor-specific (Hyprland binds, KWin scripts, GNOME extensions) |
+
+## Workspace / desktop
+
+xdotool's desktop ops assume a global virtual-desktop concept (NETWM `_NET_CURRENT_DESKTOP`). Wayland has no equivalent at the protocol level; each compositor decides whether to expose workspaces and how. None of these are planned.
+
+| xdotool command | wdotool | notes |
+| --- | --- | --- |
+| `set_desktop`, `get_desktop` | 🚫 | Use compositor IPC (`sway-msg workspace`, `hyprctl dispatch workspace`, KWin scripts) |
+| `get_num_desktops`, `set_num_desktops` | 🚫 | Same |
+| `set_desktop_for_window`, `get_desktop_for_window` | 🚫 | Same |
+| `set_desktop_viewport`, `get_desktop_viewport` | 🚫 | NETWM concept; Wayland compositors don't expose this |
+
+## X11-only properties
+
+| xdotool command | wdotool | notes |
+| --- | --- | --- |
+| `set_window`, `getwindowname`-via-properties | 🚫 | wdotool can't set X11 properties on Wayland windows because the windows aren't X11 windows. XWayland clients have an X11 window backing them, but reaching it requires a different tool entirely (`xprop`, `xdotool` itself) |
+
+## Convenience commands
+
+xdotool ships a few shell-helper commands that don't map cleanly to a Wayland tool. wdotool deliberately doesn't reimplement them; just use the shell.
+
+| xdotool command | wdotool | use instead |
+| --- | --- | --- |
+| `sleep` | 🚫 | Shell `sleep` |
+| `exec` | 🚫 | Shell |
+| Chained commands (`xdotool cmd ; cmd`) | 🚫 | Shell pipes / chains |
+
+## What about features wdotool has that xdotool doesn't
+
+- `wdotool diag` and `wdotool diag --copy` for environment introspection and bug-report capture.
+- `wdotool capabilities` for structured (JSON) introspection of what this build supports. Schema at [`capabilities-schema.json`](capabilities-schema.json).
+- A library API (`wdotool-core` on crates.io) for embedding the engine in other Rust tools.
+- Per-backend Cargo features so library consumers can drop the backends they don't need (uinput especially, for sandboxed builds).
+- Portal `restore_token` caching so libei users don't see a consent dialog on every command.
+
+## Filing missing-command requests
+
+If you find a `❌ deferred` entry that you actually need to port a script, [open an issue](https://github.com/cushycush/wdotool/issues) with:
+
+1. The xdotool command you're trying to replace.
+2. A short example of how you use it.
+3. What Wayland session you're on (run `wdotool diag --copy` and paste).
+
+The deferred items are deferred because nobody has hit them yet, not because they're hard.


### PR DESCRIPTION
## What changes

The README opened by calling wdotool an "xdotool-compatible input automation CLI." That framing was good for getting xdotool migrants to click, but it set up the wrong expectations. Half of xdotool's surface (selectwindow, behave_*, get/set_desktop, windowmove, windowsize) cannot work on Wayland by design, and a bunch more is just deferred.

This PR reframes wdotool as what it actually is: an input automation tool with both a CLI and a Rust library API, used by [wflow](https://github.com/cushycush/wflow) as its input substrate. The "Why" section explicitly says this isn't a drop-in xdotool replacement and points migrants at a new compat doc.

## What lands

- **README opening**: tagline now describes the CLI + library duality and names wflow. The "Why" section disclaims drop-in compatibility plainly and points at the new compat doc.
- **`docs/xdotool-compat.md`**: honest parity table. Grouped by category (input, window actions, window queries, workspace ops, X11-only, convenience). Each row says shipped, partial, deferred, or not planned, with a short reason. The "not planned" rows have an explanation so migrants know whether to wait for an issue or use a different tool.
- **CHANGELOG**: two new Unreleased entries (one Added for the compat doc, one Changed for the README reframe).

## What it isn't

This isn't a full README rewrite. The Backends section, the Install section, the Usage block, and the Project layout already got fixed in PR #7. This is the opening framing piece that PR #7 left for later.

## Test plan

Markdown only; no code. README renders cleanly on GitHub. The xdotool-compat doc's tables render correctly. All 36 tests still pass since nothing in the source tree moved.

## v0.2.0 status

Items 1, 2, 4, 5, 7, and 8 are done. Item 6 (KDE Plasma 6 hardware verification) is the last one before the v0.2.0 cut.