### PR TITLE
feat: real matchers for wdotool search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `wdotool search` grew real matchers. `--class` now works alongside the existing `--name` (filters on Wayland app_id, the closest equivalent to X11's WM_CLASS). `--pid` filters by exact process id. `--regex` switches `--name` and `--class` from substring matching to full regex; `--ignore-case` works in both modes. The capabilities schema's `window.match_by` field grew from `["title"]` to `["title", "app_id", "pid"]` accordingly. Exit code semantics now match xdotool: `wdotool search` returns 1 when nothing matches and 0 when it finds at least one window, so shell scripts can branch on `if wdotool search --name foo; then ...`.
+
 ## [0.2.0] — 2026-04-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,6 +700,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,6 +1283,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
+ "regex",
  "serde",
  "serde_json",
  "tokio",

--- a/docs/xdotool-compat.md
+++ b/docs/xdotool-compat.md
@@ -43,11 +43,11 @@ This page is the honest table. If you are porting a script and the command you w
 
 | xdotool command | wdotool | notes |
 | --- | --- | --- |
-| `search` | 🧪 | Implemented with `--name` (title regex) and `--class` (substring on app_id). xdotool's `--role`, `--classname`, `--screen`, `--desktop`, `--all`, `--any` are not implemented |
+| `search` | ✅ | `--name` (title), `--class` (Wayland app_id), `--pid`. Substring matching by default; pass `--regex` for full regex semantics, `--ignore-case` for case-insensitive. Exits 1 if no matches (matches xdotool's behavior). xdotool's `--role`, `--classname`, `--screen`, `--desktop`, `--all`, `--any` aren't implemented |
 | `getactivewindow` | ✅ | Returns the focused window's id |
 | `getwindowfocus` | ✅ | Same as `getactivewindow` on Wayland (Wayland does not expose pointer-focus separately from keyboard-focus to clients) |
 | `getwindowname` | ❌ | Use `wdotool search` and parse the output for now |
-| `getwindowpid` | ❌ | Same. The `pid` field is in `WindowInfo` already; just not surfaced in the CLI yet |
+| `getwindowpid` | ❌ | Same. The `pid` field is in `WindowInfo` and you can filter by it via `wdotool search --pid <n>`, but there's no dedicated `getwindowpid <id>` command yet |
 | `getwindowclassname` | ❌ |  |
 | `getwindowgeometry` | ❌ | Compositor-dependent; wlroots can do it through foreign-toplevel, KWin via scripting. Not built yet |
 

--- a/wdotool-core/src/capabilities.rs
+++ b/wdotool-core/src/capabilities.rs
@@ -173,10 +173,13 @@ pub fn report(env: &Environment, backend: &dyn Backend) -> CapabilitiesReport {
             active: caps.active_window,
             activate: caps.activate_window,
             close: caps.close_window,
-            // v0.2.0 only matches by title (`wdotool search --name`).
-            // The `match_by` array can grow without a schema bump
-            // when class / app_id / pid matchers land.
-            match_by: vec![MatchBy::Title],
+            // The CLI exposes --name (matches title), --class
+            // (substring/regex against app_id), and --pid. The schema's
+            // `class` enum value documents the user-facing flag; we
+            // also emit `app_id` because that's the actual attribute
+            // the class filter reads. Adding entries here is forward-
+            // compatible per the schema rules.
+            match_by: vec![MatchBy::Title, MatchBy::AppId, MatchBy::Pid],
         },
         extras: Extras {
             diag: true,
@@ -319,7 +322,10 @@ mod tests {
         assert!(r.backend.delegated_to.is_none());
         assert!(!r.backend.fallback_chain.is_empty());
         assert_eq!(r.input.modifiers, ModifiersCap::SendOnly);
-        assert_eq!(r.window.match_by, vec![MatchBy::Title]);
+        assert_eq!(
+            r.window.match_by,
+            vec![MatchBy::Title, MatchBy::AppId, MatchBy::Pid]
+        );
         assert!(r.extras.diag);
         assert!(!r.extras.outputs);
         assert!(!r.extras.record.supported);
@@ -352,7 +358,10 @@ mod tests {
         assert_eq!(value["backend"]["kind"], "direct");
         assert_eq!(value["input"]["modifiers"], "send-only");
         // match_by is an array of snake_case strings.
-        assert_eq!(value["window"]["match_by"], serde_json::json!(["title"]));
+        assert_eq!(
+            value["window"]["match_by"],
+            serde_json::json!(["title", "app_id", "pid"])
+        );
         // record.source is null in v0.2.0.
         assert!(value["extras"]["record"]["source"].is_null());
     }

--- a/wdotool/Cargo.toml
+++ b/wdotool/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 wdotool-core = { path = "../wdotool-core", version = "0.2.0" }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }

--- a/wdotool/src/cli.rs
+++ b/wdotool/src/cli.rs
@@ -82,12 +82,33 @@ pub enum Command {
     /// Scroll. Positive dy scrolls down; positive dx scrolls right.
     Scroll { dx: f64, dy: f64 },
 
-    /// List windows matching the filters. With no filter, lists all windows.
+    /// List windows matching the filters. With no filter, lists all
+    /// windows. Exits with status 1 if no windows matched, status 0
+    /// otherwise (matches xdotool's behavior so `if wdotool search ...`
+    /// works in shell scripts).
     Search {
+        /// Substring (or regex with --regex) matched against the
+        /// window title.
         #[arg(long)]
         name: Option<String>,
+        /// Substring (or regex with --regex) matched against the
+        /// Wayland app_id (the closest equivalent to X11's WM_CLASS).
         #[arg(long)]
         class: Option<String>,
+        /// Match windows owned by this exact PID. Backends that can't
+        /// resolve a PID for a window will never match this filter.
+        #[arg(long)]
+        pid: Option<u32>,
+        /// Treat --name and --class values as regular expressions
+        /// instead of plain substrings. Without this flag, the
+        /// patterns are escaped before matching, so `Fire.fox` matches
+        /// only that literal string.
+        #[arg(long)]
+        regex: bool,
+        /// Case-insensitive matching for --name and --class. Works in
+        /// both substring and regex modes.
+        #[arg(long)]
+        ignore_case: bool,
     },
 
     /// Print the active window's id.

--- a/wdotool/src/main.rs
+++ b/wdotool/src/main.rs
@@ -6,9 +6,11 @@ use std::time::Duration;
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
 
+use regex::Regex;
+
 use wdotool_core::detector::{self, BackendKind, Environment};
 use wdotool_core::keysym;
-use wdotool_core::{Backend, KeyDirection, MouseButton, Result, WdoError, WindowId};
+use wdotool_core::{Backend, KeyDirection, MouseButton, Result, WdoError, WindowId, WindowInfo};
 
 use cli::{Cli, Command};
 
@@ -138,15 +140,30 @@ async fn dispatch(backend: &dyn Backend, env: &Environment, cmd: Command) -> Res
         Command::Scroll { dx, dy } => {
             backend.scroll(dx, dy).await?;
         }
-        Command::Search { name, class } => {
+        Command::Search {
+            name,
+            class,
+            pid,
+            regex,
+            ignore_case,
+        } => {
             let windows = backend.list_windows().await?;
-            for w in windows.into_iter().filter(|w| {
-                name.as_deref().is_none_or(|n| w.title.contains(n))
-                    && class
-                        .as_deref()
-                        .is_none_or(|c| w.app_id.as_deref().is_some_and(|a| a.contains(c)))
-            }) {
+            let filters = SearchFilters::compile(SearchFlags {
+                name: name.as_deref(),
+                class: class.as_deref(),
+                pid,
+                regex,
+                ignore_case,
+            })?;
+            let mut matched = false;
+            for w in windows.iter().filter(|w| filters.matches(w)) {
                 println!("{}\t{}", w.id, w.title);
+                matched = true;
+            }
+            // xdotool exits 1 when nothing matched; preserve that for
+            // shell scripts that branch on `if wdotool search ...`.
+            if !matched {
+                std::process::exit(1);
             }
         }
         Command::Getactivewindow => match backend.active_window().await? {
@@ -253,4 +270,224 @@ fn init_tracing(verbose: bool) {
         .with_target(false)
         .with_writer(std::io::stderr)
         .try_init();
+}
+
+/// Inputs to [`SearchFilters::compile`]; mirrors the CLI flags so the
+/// filter compilation is testable without round-tripping through clap.
+struct SearchFlags<'a> {
+    name: Option<&'a str>,
+    class: Option<&'a str>,
+    pid: Option<u32>,
+    regex: bool,
+    ignore_case: bool,
+}
+
+/// Compiled search predicates. Built once per `wdotool search` call and
+/// then applied to each window. Holding the regex(es) here avoids
+/// recompiling per-window.
+struct SearchFilters {
+    name: Option<Regex>,
+    class: Option<Regex>,
+    pid: Option<u32>,
+}
+
+impl SearchFilters {
+    fn compile(flags: SearchFlags<'_>) -> Result<Self> {
+        let make_regex = |pat: &str, field: &'static str| -> Result<Regex> {
+            // Without --regex, escape so substring patterns are
+            // taken literally. With --ignore-case, prefix with the
+            // (?i) inline flag; works in both modes uniformly.
+            let body = if flags.regex {
+                pat.to_string()
+            } else {
+                regex::escape(pat)
+            };
+            let full = if flags.ignore_case {
+                format!("(?i){body}")
+            } else {
+                body
+            };
+            Regex::new(&full)
+                .map_err(|e| WdoError::InvalidArg(format!("invalid {field} pattern {pat:?}: {e}")))
+        };
+        Ok(Self {
+            name: flags.name.map(|p| make_regex(p, "--name")).transpose()?,
+            class: flags.class.map(|p| make_regex(p, "--class")).transpose()?,
+            pid: flags.pid,
+        })
+    }
+
+    fn matches(&self, w: &WindowInfo) -> bool {
+        if let Some(re) = &self.name {
+            if !re.is_match(&w.title) {
+                return false;
+            }
+        }
+        if let Some(re) = &self.class {
+            // app_id is the Wayland equivalent of WM_CLASS. Backends
+            // that don't expose it (uinput, bare libei) can't match
+            // here at all, which is correct.
+            match w.app_id.as_deref() {
+                Some(a) if re.is_match(a) => {}
+                _ => return false,
+            }
+        }
+        if let Some(p) = self.pid {
+            if w.pid != Some(p) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod search_tests {
+    use super::*;
+    use wdotool_core::WindowId;
+
+    fn win(id: &str, title: &str, app_id: Option<&str>, pid: Option<u32>) -> WindowInfo {
+        WindowInfo {
+            id: WindowId(id.into()),
+            title: title.into(),
+            app_id: app_id.map(str::to_string),
+            pid,
+        }
+    }
+
+    fn flags<'a>(
+        name: Option<&'a str>,
+        class: Option<&'a str>,
+        pid: Option<u32>,
+    ) -> SearchFlags<'a> {
+        SearchFlags {
+            name,
+            class,
+            pid,
+            regex: false,
+            ignore_case: false,
+        }
+    }
+
+    #[test]
+    fn substring_name_match_is_default() {
+        let f = SearchFilters::compile(flags(Some("fox"), None, None)).unwrap();
+        assert!(f.matches(&win("1", "Firefox", None, None)));
+        assert!(!f.matches(&win("2", "Chromium", None, None)));
+    }
+
+    #[test]
+    fn dot_in_pattern_is_escaped_without_regex_flag() {
+        // With --regex off, `Fire.fox` only matches the literal string,
+        // not `Fire?fox` (which a regex would match).
+        let f = SearchFilters::compile(flags(Some("Fire.fox"), None, None)).unwrap();
+        assert!(!f.matches(&win("1", "Firefox", None, None)));
+        assert!(f.matches(&win("2", "Fire.fox Browser", None, None)));
+    }
+
+    #[test]
+    fn regex_flag_enables_pattern_semantics() {
+        let f = SearchFilters::compile(SearchFlags {
+            name: Some("Fire.*x"),
+            class: None,
+            pid: None,
+            regex: true,
+            ignore_case: false,
+        })
+        .unwrap();
+        assert!(f.matches(&win("1", "Firefox", None, None)));
+        assert!(!f.matches(&win("2", "Chromium", None, None)));
+    }
+
+    #[test]
+    fn ignore_case_works_in_substring_mode() {
+        let f = SearchFilters::compile(SearchFlags {
+            name: Some("FIREFOX"),
+            class: None,
+            pid: None,
+            regex: false,
+            ignore_case: true,
+        })
+        .unwrap();
+        assert!(f.matches(&win("1", "Mozilla Firefox", None, None)));
+    }
+
+    #[test]
+    fn ignore_case_works_in_regex_mode() {
+        let f = SearchFilters::compile(SearchFlags {
+            name: Some("FIRE.*X"),
+            class: None,
+            pid: None,
+            regex: true,
+            ignore_case: true,
+        })
+        .unwrap();
+        assert!(f.matches(&win("1", "Mozilla Firefox", None, None)));
+    }
+
+    #[test]
+    fn class_filter_matches_app_id() {
+        let f = SearchFilters::compile(flags(None, Some("firefox"), None)).unwrap();
+        assert!(f.matches(&win("1", "Some Page", Some("org.mozilla.firefox"), None)));
+        assert!(!f.matches(&win("2", "kitty", Some("kitty"), None)));
+    }
+
+    #[test]
+    fn class_filter_skips_windows_without_app_id() {
+        let f = SearchFilters::compile(flags(None, Some("anything"), None)).unwrap();
+        // app_id None means the backend doesn't expose it (uinput,
+        // bare libei). Such windows can never satisfy a class filter.
+        assert!(!f.matches(&win("1", "Some Page", None, None)));
+    }
+
+    #[test]
+    fn pid_filter_requires_exact_match() {
+        let f = SearchFilters::compile(flags(None, None, Some(1234))).unwrap();
+        assert!(f.matches(&win("1", "Firefox", None, Some(1234))));
+        assert!(!f.matches(&win("2", "Firefox", None, Some(5678))));
+        // Backends that don't populate pid never match a pid filter.
+        assert!(!f.matches(&win("3", "Firefox", None, None)));
+    }
+
+    #[test]
+    fn filters_are_anded_together() {
+        let f =
+            SearchFilters::compile(flags(Some("Firefox"), Some("mozilla"), Some(1234))).unwrap();
+        assert!(f.matches(&win(
+            "1",
+            "Firefox - Wikipedia",
+            Some("org.mozilla.firefox"),
+            Some(1234)
+        )));
+        // Right title + class but wrong pid: rejected.
+        assert!(!f.matches(&win(
+            "2",
+            "Firefox - Wikipedia",
+            Some("org.mozilla.firefox"),
+            Some(5678)
+        )));
+    }
+
+    #[test]
+    fn no_filters_matches_everything() {
+        let f = SearchFilters::compile(flags(None, None, None)).unwrap();
+        assert!(f.matches(&win("1", "Anything", None, None)));
+        assert!(f.matches(&win("2", "Else", Some("kitty"), Some(99))));
+    }
+
+    #[test]
+    fn invalid_regex_pattern_returns_invalid_arg() {
+        let result = SearchFilters::compile(SearchFlags {
+            name: Some("[unclosed"),
+            class: None,
+            pid: None,
+            regex: true,
+            ignore_case: false,
+        });
+        match result {
+            Err(WdoError::InvalidArg(msg)) => assert!(msg.contains("--name")),
+            Err(other) => panic!("expected InvalidArg, got {other:?}"),
+            Ok(_) => panic!("expected InvalidArg, got Ok"),
+        }
+    }
 }


### PR DESCRIPTION
## What this fixes

The old `wdotool search` only matched on title (`--name`) and app_id (`--class`), both as case-sensitive substrings, and exited 0 even when no windows matched. That was fine for the simplest one-off scripts but blocked anything more substantial: no PID filter, no regex, no case-insensitive option, and `if wdotool search ...; then` in shell scripts silently always took the true branch because the exit code stayed at 0 even on no-match.

## What ships

Three new flags on `search`:

```sh
wdotool search --pid 1234           # filter to windows from this PID
wdotool search --name foo --regex   # --name + --class become regex patterns
wdotool search --name FOO --ignore-case   # case-insensitive matching
```

Substring is still the default; `--regex` opts into pattern semantics. Without `--regex`, the input is escaped (so `Fire.fox` matches the literal string, not "Fire" + any-char + "fox"). `--ignore-case` works in both modes.

Exit codes now match xdotool: 0 if at least one window matched, 1 if nothing did. Shell scripts can branch on `if wdotool search --name foo; then ...` and have it actually work.

The capabilities schema's `window.match_by` field grew from `["title"]` to `["title", "app_id", "pid"]`. The schema enum already reserved these values, so the change is forward-compatible per the schema rules and doesn't bump `schema_version`.

## Implementation notes

The matcher compiles once per `wdotool search` invocation (one regex per flag) instead of per window, so a search across hundreds of windows doesn't recompile patterns each iteration. The regex / matcher logic lives behind two small structs (`SearchFlags`, `SearchFilters`) so the compilation and predicate evaluation are unit-testable without a live compositor.

11 new tests cover substring versus regex, case folding in both modes, the app_id mapping for `--class`, behavior when a backend doesn't expose `app_id` (uinput / bare libei), exact PID matching, AND semantics across multiple filters, no-filter behavior, and invalid-regex error reporting.

`regex` 1.x is a new dep on the `wdotool` CLI crate. Five small transitive crates (aho-corasick, regex-syntax, regex-automata, matchers, plus regex itself). `wdotool-core` still has zero regex dependencies.

## Test plan

- 47 tests pass (18 wdotool + 29 wdotool-core, was 36).
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean.
- Live verified on Hyprland: `--name` substring, `--regex` with `--ignore-case`, the exit-1 no-match path, and `wdotool capabilities` reflecting the new `match_by` list all behave correctly.

## What this isn't

xdotool's `--role`, `--classname`, `--screen`, `--desktop`, `--all`, `--any` are still unimplemented. The `docs/xdotool-compat.md` row for `search` is updated to spell out the current state and the remaining gaps.