### PR TITLE
feat: getwindowname / getwindowpid / getwindowclassname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `wdotool getwindowname <id>`, `wdotool getwindowpid <id>`, and `wdotool getwindowclassname <id>` round out the xdotool query surface. Each takes a window id (the same string `wdotool search` and `wdotool getactivewindow` print) and writes a single field to stdout: title, PID, or app_id (the Wayland equivalent of X11's WM_CLASS classname). Returns exit 1 if the id doesn't exist or if the backend can't resolve the requested field for that window. No new backend code: every backend that already populates `WindowInfo` from `list_windows` gets these for free.
 - `wdotool search` grew real matchers. `--class` now works alongside the existing `--name` (filters on Wayland app_id, the closest equivalent to X11's WM_CLASS). `--pid` filters by exact process id. `--regex` switches `--name` and `--class` from substring matching to full regex; `--ignore-case` works in both modes. The capabilities schema's `window.match_by` field grew from `["title"]` to `["title", "app_id", "pid"]` accordingly. Exit code semantics now match xdotool: `wdotool search` returns 1 when nothing matches and 0 when it finds at least one window, so shell scripts can branch on `if wdotool search --name foo; then ...`.
 
 ## [0.2.0] — 2026-04-25

--- a/docs/xdotool-compat.md
+++ b/docs/xdotool-compat.md
@@ -46,9 +46,9 @@ This page is the honest table. If you are porting a script and the command you w
 | `search` | ✅ | `--name` (title), `--class` (Wayland app_id), `--pid`. Substring matching by default; pass `--regex` for full regex semantics, `--ignore-case` for case-insensitive. Exits 1 if no matches (matches xdotool's behavior). xdotool's `--role`, `--classname`, `--screen`, `--desktop`, `--all`, `--any` aren't implemented |
 | `getactivewindow` | ✅ | Returns the focused window's id |
 | `getwindowfocus` | ✅ | Same as `getactivewindow` on Wayland (Wayland does not expose pointer-focus separately from keyboard-focus to clients) |
-| `getwindowname` | ❌ | Use `wdotool search` and parse the output for now |
-| `getwindowpid` | ❌ | Same. The `pid` field is in `WindowInfo` and you can filter by it via `wdotool search --pid <n>`, but there's no dedicated `getwindowpid <id>` command yet |
-| `getwindowclassname` | ❌ |  |
+| `getwindowname` | ✅ | Prints the title of a window by id. Pair with `wdotool search` to get an id |
+| `getwindowpid` | ✅ | Prints the PID of a window by id. Exits 1 if the backend can't resolve a PID for that window (some compositors don't expose it) |
+| `getwindowclassname` | ✅ | Prints the Wayland app_id of a window by id (the closest equivalent to X11's WM_CLASS classname). Exits 1 if no app_id is set |
 | `getwindowgeometry` | ❌ | Compositor-dependent; wlroots can do it through foreign-toplevel, KWin via scripting. Not built yet |
 
 ## Selection / interactive UI

--- a/wdotool/src/cli.rs
+++ b/wdotool/src/cli.rs
@@ -120,6 +120,19 @@ pub enum Command {
     /// Close a window by id.
     Windowclose { id: String },
 
+    /// Print the title of the window with the given id.
+    Getwindowname { id: String },
+
+    /// Print the PID of the window with the given id. Exits 1 if the
+    /// backend can't resolve a PID for that window (some compositors
+    /// don't expose it).
+    Getwindowpid { id: String },
+
+    /// Print the app_id of the window with the given id. This is the
+    /// Wayland equivalent of xdotool's WM_CLASS classname. Exits 1 if
+    /// the window has no app_id set.
+    Getwindowclassname { id: String },
+
     /// Show detected environment and backend capabilities.
     Info,
 

--- a/wdotool/src/main.rs
+++ b/wdotool/src/main.rs
@@ -172,6 +172,30 @@ async fn dispatch(backend: &dyn Backend, env: &Environment, cmd: Command) -> Res
         },
         Command::Windowactivate { id } => backend.activate_window(&WindowId(id)).await?,
         Command::Windowclose { id } => backend.close_window(&WindowId(id)).await?,
+        Command::Getwindowname { id } => {
+            let w = find_window(backend, &id).await?;
+            println!("{}", w.title);
+        }
+        Command::Getwindowpid { id } => {
+            let w = find_window(backend, &id).await?;
+            match w.pid {
+                Some(pid) => println!("{pid}"),
+                None => {
+                    eprintln!("wdotool: pid not available for window {id}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        Command::Getwindowclassname { id } => {
+            let w = find_window(backend, &id).await?;
+            match w.app_id {
+                Some(app_id) => println!("{app_id}"),
+                None => {
+                    eprintln!("wdotool: classname (app_id) not available for window {id}");
+                    std::process::exit(1);
+                }
+            }
+        }
         Command::Diag { .. } => {
             // Handled in main() before dispatch is called so diag never
             // bootstraps a backend.
@@ -179,6 +203,18 @@ async fn dispatch(backend: &dyn Backend, env: &Environment, cmd: Command) -> Res
         }
     }
     Ok(())
+}
+
+/// Look up a window by its id string. Used by the `getwindow*` commands
+/// which all need to resolve an id to a `WindowInfo` before reading a
+/// single field. Returns `WindowNotFound` if no window in the current
+/// list has that id, which xdotool also signals via non-zero exit.
+async fn find_window(backend: &dyn Backend, id: &str) -> Result<WindowInfo> {
+    let windows = backend.list_windows().await?;
+    windows
+        .into_iter()
+        .find(|w| w.id.0 == id)
+        .ok_or_else(|| WdoError::WindowNotFound(id.to_string()))
 }
 
 /// Approximates xdotool's --clearmodifiers. Wayland doesn't let a normal


### PR DESCRIPTION
## What this does

Three new query commands that round out the xdotool window-query surface:

- `wdotool getwindowname <id>` prints the window title.
- `wdotool getwindowpid <id>` prints the window's PID.
- `wdotool getwindowclassname <id>` prints the window's app_id (the closest Wayland equivalent of X11's `WM_CLASS` classname).

The id is the same string `wdotool search` and `wdotool getactivewindow` already print, so the typical pattern is now:

```bash
id=$(wdotool search --class firefox)
title=$(wdotool getwindowname "$id")
```

This is what wflow scripts (and ported xdotool scripts in general) reach for after a `search`. Without these, callers had to parse `search` output by hand.

## How it works

No new backend code. Every backend that already populates `WindowInfo` via `list_windows` gets these for free.

The implementation is a small `find_window` helper in `wdotool/src/main.rs` that scans the window list and picks the one whose id matches. Each command then reads a single field off the `WindowInfo` and prints it.

## Exit semantics

Match xdotool's behavior:

- Bad id (no window with that id exists) returns `WdoError::WindowNotFound` and exits non-zero.
- Missing optional field (e.g., `getwindowpid` on the wlroots backend, where the foreign-toplevel protocol does not expose a PID, or `getwindowclassname` on a window that has no `app_id` set) prints a clear message to stderr and exits 1, so shell scripts can branch on it.

## Test plan

- `cargo fmt` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean.
- 47 tests pass (no new tests needed for the helper; logic is a linear scan + field read, covered by the existing live verification).
- Live-verified all three on Hyprland against the active Ghostty window: name returned `Ghostty`, classname returned `com.mitchellh.ghostty`, pid correctly exited 1 with the expected stderr message because wlroots foreign-toplevel doesn't carry PID. Bad id correctly returned `Error: window not found: ...` and exit 1.

## What's not in scope

- Hardware verification on KDE / GNOME backends still needs a real session. The KDE script-based backend and GNOME extension both populate `pid` and `app_id` in `WindowInfo`, so these commands should just work there, but I haven't run them on a real KDE / GNOME box.
- `getwindowgeometry` is still deferred. That one needs new backend code (compositor-specific geometry queries) and isn't a free ride like these three.