### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-04-26
+
 ### Added
 - `wdotool search --any` flips filter combination from the default AND to OR. With multiple filters set (`--name`, `--class`, `--pid`), the default behavior requires every filter to match; `--any` accepts a window if at least one set filter matches. `--all` is also accepted as a no-op for xdotool argv compatibility, since it just names the existing default. The two flags are mutually exclusive (clap rejects with exit 2). With no filters set, `--any` falls through to "list everything" so that `wdotool search --any` and `wdotool search` behave the same with zero filters.
 - `@wdotool/capabilities` npm package. TypeScript types and the JSON Schema document for the `wdotool capabilities` output, packaged so JS/TS consumers (wflows.com, dashboards, config UIs) can parse a capabilities report with full type safety. Exports `CapabilitiesReport` and the supporting types, an `isCapabilitiesReport` runtime guard, and the schema itself for use with ajv. Source under `packaging/npm/`. The schema is synced from `docs/capabilities-schema.json` at build time, and CI fails if the locked enums in `src/types.ts` drift from the schema. First publish is manual via the new `npm publish` workflow once the npm org is set up.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "wdotool"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "wdotool-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ashpd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["wdotool-core", "wdotool"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cushycush/wdotool"

--- a/packaging/npm/package-lock.json
+++ b/packaging/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wdotool/capabilities",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wdotool/capabilities",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdotool/capabilities",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "TypeScript types and JSON Schema for wdotool's `wdotool capabilities` output. Lets JS/TS consumers (wflows.com, dashboards, etc.) parse a capabilities report with full type safety.",
   "type": "module",
   "main": "dist/index.js",

--- a/wdotool/Cargo.toml
+++ b/wdotool/Cargo.toml
@@ -16,7 +16,7 @@ name = "wdotool"
 path = "src/main.rs"
 
 [dependencies]
-wdotool-core = { path = "../wdotool-core", version = "0.2.0" }
+wdotool-core = { path = "../wdotool-core", version = "0.3.0" }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 regex = "1"


### PR DESCRIPTION
## What this is

Release commit for v0.3.0. Same shape as v0.2.0's release PR: bump versions, date the CHANGELOG, ship. After this merges, I'll tag `v0.3.0` on main and the existing pipelines (cargo-dist + crates-io + distros + AUR) take it from there.

## What's in v0.3.0

Polish on top of v0.2.0, with the xdotool migration story closer to complete.

`wdotool search` is the bigger story this release. v0.2.0 shipped it as a thin wrapper that only matched on title; v0.3.0 grew it into a real matcher with `--class` (Wayland app_id), `--pid`, `--regex`, `--ignore-case`, and `--any` for OR filter combination. `--all` is also accepted as a no-op for argv compatibility with xdotool scripts that pass it explicitly. Exit code now matches xdotool: 1 when nothing matched, 0 otherwise, so `if wdotool search ...; then ...` works in shell.

Three new query commands fill the rest of the xdotool window-query gap: `getwindowname <id>`, `getwindowpid <id>`, `getwindowclassname <id>`. Each takes a window id and prints one field. Exits 1 if the id doesn't exist or the backend can't resolve the requested field (e.g., wlroots foreign-toplevel doesn't carry PIDs).

For downstream JS and TS tools that consume `wdotool capabilities`, we now ship `@wdotool/capabilities` on npm (under `packaging/npm/`). Hand-written TypeScript types live next to the JSON Schema document, with CI-enforced drift checks on the locked enums. First publish to npm is manual (you'll need the `@wdotool` org and `NPM_TOKEN` set up); the workflow is in place at `.github/workflows/npm-publish.yml`.

## Version bumps

- `Cargo.toml` workspace: 0.2.0 → 0.3.0 (cascades to wdotool + wdotool-core)
- `wdotool/Cargo.toml` inner pin on wdotool-core: 0.2.0 → 0.3.0
- `Cargo.lock` regenerated
- `packaging/npm/package.json`: 0.2.0 → 0.3.0
- `packaging/npm/package-lock.json` regenerated

## What's NOT in this PR

The AUR PKGBUILDs in `packaging/aur/*/PKGBUILD` are intentionally not bumped here. The aur.yml workflow patches them on the fly during tag deploy and pushes to the AUR side; the in-repo files are starter templates.

The Flathub manifest at `packaging/flatpak/` is also not bumped. Flathub submission is a separate manual step (PR to flathub/flathub) and isn't tied to this release cut.

## Test plan

53 Rust tests pass via `cargo test --workspace`. 8 npm tests pass via `npm test` from `packaging/npm/`. `cargo fmt` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean. CI will re-run all of this on the PR.