### PR TITLE
feat: wdotool getmouselocation (KDE + GNOME)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `wdotool getmouselocation` reads the compositor's current pointer position and prints it as `x:N y:N` (xdotool's default format). First read-side input API in wdotool: every prior command was a send-side virtual-pointer or virtual-keyboard call. Supported on KDE (kwin script reading `workspace.cursorPos`) and GNOME (Shell extension calling `global.get_pointer()`); exits 1 with a clear stderr message on libei / wlroots / uinput because their Wayland protocols are send-only by design. Capabilities schema's `extras` grew a `pointer_position` boolean reporting backend support.
+- GNOME companion Shell extension: new `GetPointerPosition` D-Bus method on `org.wdotool.GnomeShellBridge`. If you already have an older copy of the extension installed, reinstall from `packaging/gnome-extension/wdotool@wdotool.github.io/` to pick up the new method (older copies will return a D-Bus error on `getmouselocation`).
+
 ## [0.3.0] — 2026-04-26
 
 ### Added

--- a/docs/capabilities-schema.json
+++ b/docs/capabilities-schema.json
@@ -99,7 +99,7 @@
     },
     "extras": {
       "type": "object",
-      "required": ["diag", "outputs", "record", "json_output"],
+      "required": ["diag", "outputs", "record", "json_output", "pointer_position"],
       "properties": {
         "diag": {
           "type": "boolean",
@@ -125,6 +125,10 @@
         "json_output": {
           "type": "boolean",
           "description": "Whether commands accept `--json` for structured output. v0.2.0: true (diag and capabilities support it)."
+        },
+        "pointer_position": {
+          "type": "boolean",
+          "description": "Whether `wdotool getmouselocation` can read the compositor's current pointer position on the selected backend. KDE (kwin script) and GNOME (Shell extension) emit `true`; libei, wlroots, and uinput emit `false` because the relevant Wayland protocols are send-only."
         }
       }
     },

--- a/docs/xdotool-compat.md
+++ b/docs/xdotool-compat.md
@@ -24,7 +24,7 @@ This page is the honest table. If you are porting a script and the command you w
 | `click` | ✅ | xdotool indices: 1=left, 2=middle, 3=right, 8=back, 9=forward |
 | `mousedown`, `mouseup` | ✅ |  |
 | `mousewheeldown`, `mousewheelup` | ✅ | Use `wdotool scroll dx dy` |
-| `getmouselocation` | ❌ | Pure send-side surface today; no read of pointer position. Open an issue if you need it |
+| `getmouselocation` | 🧪 | KDE (kwin script) and GNOME (Shell extension) both read the compositor's pointer position. libei / wlroots / uinput exit 1 with a clear message because the relevant Wayland protocols are send-only. Use your compositor's IPC there (`hyprctl cursorpos`, `swaymsg get_seats`) |
 
 ## Window actions
 

--- a/packaging/gnome-extension/wdotool@wdotool.github.io/extension.js
+++ b/packaging/gnome-extension/wdotool@wdotool.github.io/extension.js
@@ -35,6 +35,10 @@ const IFACE_XML = `
       <arg type="s" direction="in" name="id"/>
       <arg type="b" direction="out" name="ok"/>
     </method>
+    <method name="GetPointerPosition">
+      <arg type="i" direction="out" name="x"/>
+      <arg type="i" direction="out" name="y"/>
+    </method>
   </interface>
 </node>`;
 
@@ -117,5 +121,14 @@ export default class WdotoolExtension extends Extension {
         if (!w) return false;
         w.delete(global.get_current_time());
         return true;
+    }
+
+    // Returns [x, y] in compositor coordinates. global.get_pointer()
+    // also returns a third element (modifier mask), which we drop —
+    // wdotool exposes pointer reads via its own modifier-aware API
+    // path, not as a side effect of pointer queries.
+    GetPointerPosition() {
+        const [x, y] = global.get_pointer();
+        return [x | 0, y | 0];
     }
 }

--- a/packaging/gnome-extension/wdotool@wdotool.github.io/metadata.json
+++ b/packaging/gnome-extension/wdotool@wdotool.github.io/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "wdotool@wdotool.github.io",
   "name": "wdotool bridge",
-  "description": "Exposes GNOME Shell window management to the wdotool CLI via a session-bus D-Bus service. No background activity — only handles incoming method calls from the wdotool client.",
+  "description": "Exposes GNOME Shell window management and pointer-position queries to the wdotool CLI via a session-bus D-Bus service. No background activity — only handles incoming method calls from the wdotool client.",
   "shell-version": ["45", "46", "47", "48"],
   "url": "https://github.com/cushycush/wdotool"
 }

--- a/packaging/npm/src/schema.json
+++ b/packaging/npm/src/schema.json
@@ -99,7 +99,7 @@
     },
     "extras": {
       "type": "object",
-      "required": ["diag", "outputs", "record", "json_output"],
+      "required": ["diag", "outputs", "record", "json_output", "pointer_position"],
       "properties": {
         "diag": {
           "type": "boolean",
@@ -125,6 +125,10 @@
         "json_output": {
           "type": "boolean",
           "description": "Whether commands accept `--json` for structured output. v0.2.0: true (diag and capabilities support it)."
+        },
+        "pointer_position": {
+          "type": "boolean",
+          "description": "Whether `wdotool getmouselocation` can read the compositor's current pointer position on the selected backend. KDE (kwin script) and GNOME (Shell extension) emit `true`; libei, wlroots, and uinput emit `false` because the relevant Wayland protocols are send-only."
         }
       }
     },

--- a/packaging/npm/src/types.ts
+++ b/packaging/npm/src/types.ts
@@ -67,6 +67,7 @@ export interface ExtrasCapabilities {
   outputs: boolean;
   record: RecordCapability;
   json_output: boolean;
+  pointer_position: boolean;
 }
 
 export interface PlatformInfo {

--- a/packaging/npm/tests/index.test.js
+++ b/packaging/npm/tests/index.test.js
@@ -39,6 +39,7 @@ const validReport = {
     outputs: false,
     record: { supported: false, source: null },
     json_output: true,
+    pointer_position: false,
   },
   platform: {
     desktop: "Hyprland",

--- a/wdotool-core/src/backend/gnome.rs
+++ b/wdotool-core/src/backend/gnome.rs
@@ -38,6 +38,8 @@ trait Bridge {
     fn activate_window(&self, id: &str) -> zbus::Result<bool>;
     #[zbus(name = "CloseWindow")]
     fn close_window(&self, id: &str) -> zbus::Result<bool>;
+    #[zbus(name = "GetPointerPosition")]
+    fn get_pointer_position(&self) -> zbus::Result<(i32, i32)>;
 }
 
 pub struct GnomeExtBackend {
@@ -137,6 +139,7 @@ impl Backend for GnomeExtBackend {
         caps.active_window = true;
         caps.activate_window = true;
         caps.close_window = true;
+        caps.pointer_position = true;
         caps
     }
 
@@ -196,5 +199,10 @@ impl Backend for GnomeExtBackend {
             return Err(WdoError::WindowNotFound(id.0.clone()));
         }
         Ok(())
+    }
+
+    async fn pointer_position(&self) -> Result<Option<(i32, i32)>> {
+        let (x, y) = self.proxy.get_pointer_position().await.map_err(dbus_err)?;
+        Ok(Some((x, y)))
     }
 }

--- a/wdotool-core/src/backend/kde.rs
+++ b/wdotool-core/src/backend/kde.rs
@@ -41,6 +41,7 @@ struct PendingState {
     list_waiters: HashMap<u64, oneshot::Sender<String>>,
     active_waiters: HashMap<u64, oneshot::Sender<String>>,
     action_waiters: HashMap<u64, oneshot::Sender<bool>>,
+    pointer_waiters: HashMap<u64, oneshot::Sender<Option<(i32, i32)>>>,
 }
 
 /// D-Bus interface our KWin scripts call back into. Names are PascalCase on
@@ -70,6 +71,19 @@ impl Bridge {
         let sender = self.pending.lock().await.action_waiters.remove(&req_id);
         if let Some(tx) = sender {
             let _ = tx.send(ok);
+        }
+    }
+
+    /// Pointer-position result. `ok=false` means the script couldn't
+    /// read `workspace.cursorPos` (very old KWin? unusual session?); the
+    /// x/y values are then placeholders and the caller turns it into
+    /// `Ok(None)`. xdotool's getmouselocation only ever returns
+    /// coordinates, so this two-stage shape exists purely for safety
+    /// against the rare "cursor not on any screen" case.
+    async fn report_pointer(&self, req_id: u64, ok: bool, x: i32, y: i32) {
+        let sender = self.pending.lock().await.pointer_waiters.remove(&req_id);
+        if let Some(tx) = sender {
+            let _ = tx.send(if ok { Some((x, y)) } else { None });
         }
     }
 }
@@ -230,6 +244,27 @@ impl KdeBackend {
         Ok(Some(parsed.into()))
     }
 
+    async fn pointer_position_impl(&self) -> Result<Option<(i32, i32)>> {
+        let req_id = self.next_request_id();
+        let (tx, rx) = oneshot::channel::<Option<(i32, i32)>>();
+        self.pending.lock().await.pointer_waiters.insert(req_id, tx);
+
+        let script = pointer_position_script(req_id);
+        self.run_kwin_script(&script).await?;
+
+        let result = tokio::time::timeout(Duration::from_secs(3), rx)
+            .await
+            .map_err(|_| WdoError::Backend {
+                backend: NAME,
+                source: "timed out waiting for KWin pointer callback".into(),
+            })?
+            .map_err(|_| WdoError::Backend {
+                backend: NAME,
+                source: "KWin pointer script aborted before callback".into(),
+            })?;
+        Ok(result)
+    }
+
     /// Register a oneshot waiter, ask the caller to build the matching script
     /// (so the request id embedded in the JS lines up with the waiter key),
     /// run it, and return the script's boolean result. Callers map `false`
@@ -313,6 +348,28 @@ fn active_window_script(req_id: u64) -> String {
   callDBus(
     "{service}", "{path}", "{iface}", "ReportActive",
     {id}, payload
+  );
+}})();
+"#,
+        service = BRIDGE_SERVICE,
+        path = BRIDGE_PATH,
+        iface = BRIDGE_IFACE,
+        id = req_id
+    )
+}
+
+fn pointer_position_script(req_id: u64) -> String {
+    // workspace.cursorPos returns a QPoint with .x and .y in compositor
+    // coordinates. Coerce to plain numbers so `callDBus` sends them as
+    // i32, matching the Bridge::report_pointer signature.
+    format!(
+        r#"
+(function() {{
+  var p = workspace.cursorPos;
+  var ok = (p && typeof p.x === "number" && typeof p.y === "number");
+  callDBus(
+    "{service}", "{path}", "{iface}", "ReportPointer",
+    {id}, ok, ok ? (p.x | 0) : 0, ok ? (p.y | 0) : 0
   );
 }})();
 "#,
@@ -412,6 +469,7 @@ impl Backend for KdeBackend {
         caps.active_window = true;
         caps.activate_window = true;
         caps.close_window = true;
+        caps.pointer_position = true;
         caps
     }
 
@@ -433,6 +491,10 @@ impl Backend for KdeBackend {
 
     async fn scroll(&self, dx: f64, dy: f64) -> Result<()> {
         self.libei.scroll(dx, dy).await
+    }
+
+    async fn pointer_position(&self) -> Result<Option<(i32, i32)>> {
+        self.pointer_position_impl().await
     }
 
     async fn list_windows(&self) -> Result<Vec<WindowInfo>> {

--- a/wdotool-core/src/backend/libei.rs
+++ b/wdotool-core/src/backend/libei.rs
@@ -537,6 +537,7 @@ impl Backend for LibeiBackend {
             active_window: false,
             activate_window: false,
             close_window: false,
+            pointer_position: false,
         }
     }
 

--- a/wdotool-core/src/backend/mod.rs
+++ b/wdotool-core/src/backend/mod.rs
@@ -34,6 +34,16 @@ pub trait Backend: Send + Sync {
     async fn active_window(&self) -> Result<Option<WindowInfo>>;
     async fn activate_window(&self, id: &WindowId) -> Result<()>;
     async fn close_window(&self, id: &WindowId) -> Result<()>;
+
+    /// Read the compositor's current pointer position in screen
+    /// coordinates. Returns `Ok(None)` for backends that can't expose
+    /// it: libei is send-only by design, wlroots' virtual-pointer is
+    /// likewise send-only with no read protocol, and uinput is at the
+    /// kernel layer with no notion of "screen". KDE reads via a
+    /// transient kwin script, GNOME via the companion Shell extension.
+    async fn pointer_position(&self) -> Result<Option<(i32, i32)>> {
+        Ok(None)
+    }
 }
 
 pub type DynBackend = Box<dyn Backend>;

--- a/wdotool-core/src/backend/uinput.rs
+++ b/wdotool-core/src/backend/uinput.rs
@@ -266,6 +266,7 @@ impl Backend for UinputBackend {
             active_window: false,
             activate_window: false,
             close_window: false,
+            pointer_position: false,
         }
     }
 

--- a/wdotool-core/src/backend/wlroots.rs
+++ b/wdotool-core/src/backend/wlroots.rs
@@ -295,6 +295,7 @@ fn worker_main(
         active_window: state.scratch.ft_mgr.is_some(),
         activate_window: state.scratch.ft_mgr.is_some() && seat.is_some(),
         close_window: state.scratch.ft_mgr.is_some(),
+        pointer_position: false,
     };
     if ready_tx.send(Ok(caps)).is_err() {
         return;

--- a/wdotool-core/src/capabilities.rs
+++ b/wdotool-core/src/capabilities.rs
@@ -112,6 +112,7 @@ pub struct Extras {
     pub outputs: bool,
     pub record: RecordCaps,
     pub json_output: bool,
+    pub pointer_position: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -191,6 +192,10 @@ pub fn report(env: &Environment, backend: &dyn Backend) -> CapabilitiesReport {
             // wdotool diag --json + wdotool capabilities both emit
             // structured output, so the flag is true.
             json_output: true,
+            // Tracks `wdotool getmouselocation`. Reflects the selected
+            // backend's `pointer_position` capability bit, so KDE +
+            // GNOME emit `true`, libei / wlroots / uinput emit `false`.
+            pointer_position: caps.pointer_position,
         },
         platform: PlatformInfo {
             desktop: env.desktop.clone(),
@@ -271,6 +276,7 @@ mod tests {
                 active_window: true,
                 activate_window: true,
                 close_window: true,
+                pointer_position: true,
             }
         }
         async fn key(&self, _: &str, _: KeyDirection) -> Result<()> {
@@ -331,6 +337,9 @@ mod tests {
         assert!(!r.extras.record.supported);
         assert!(r.extras.record.source.is_none());
         assert!(r.extras.json_output);
+        // FakeBackend in this test sets pointer_position=true, so the
+        // report should pass it through. Real libei would emit false.
+        assert!(r.extras.pointer_position);
         assert_eq!(r.platform.desktop.as_deref(), Some("GNOME"));
     }
 

--- a/wdotool-core/src/types.rs
+++ b/wdotool-core/src/types.rs
@@ -10,6 +10,7 @@ pub struct Capabilities {
     pub active_window: bool,
     pub activate_window: bool,
     pub close_window: bool,
+    pub pointer_position: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/wdotool/src/cli.rs
+++ b/wdotool/src/cli.rs
@@ -125,6 +125,11 @@ pub enum Command {
     /// Print the active window's id.
     Getactivewindow,
 
+    /// Print the current pointer position as `x:N y:N` (xdotool's
+    /// default format). Exits 1 on backends that can't read pointer
+    /// position (libei, wlroots, uinput); KDE and GNOME both can.
+    Getmouselocation,
+
     /// Activate (raise + focus) a window by id.
     Windowactivate { id: String },
 

--- a/wdotool/src/main.rs
+++ b/wdotool/src/main.rs
@@ -77,6 +77,7 @@ async fn dispatch(backend: &dyn Backend, env: &Environment, cmd: Command) -> Res
             println!("  active_window:         {}", caps.active_window);
             println!("  activate_window:       {}", caps.activate_window);
             println!("  close_window:          {}", caps.close_window);
+            println!("  pointer_position:      {}", caps.pointer_position);
         }
         Command::Key {
             clearmodifiers,
@@ -172,6 +173,18 @@ async fn dispatch(backend: &dyn Backend, env: &Environment, cmd: Command) -> Res
         Command::Getactivewindow => match backend.active_window().await? {
             Some(w) => println!("{}", w.id),
             None => return Err(WdoError::WindowNotFound("active".into())),
+        },
+        Command::Getmouselocation => match backend.pointer_position().await? {
+            Some((x, y)) => println!("x:{x} y:{y}"),
+            None => {
+                eprintln!(
+                    "wdotool: pointer position is unreadable on the {} backend (Wayland \
+                     virtual-pointer protocols are send-only). Use the kde or gnome backend, \
+                     or your compositor's IPC (hyprctl cursorpos, swaymsg get_seats).",
+                    backend.name()
+                );
+                std::process::exit(1);
+            }
         },
         Command::Windowactivate { id } => backend.activate_window(&WindowId(id)).await?,
         Command::Windowclose { id } => backend.close_window(&WindowId(id)).await?,


### PR DESCRIPTION
## What this does

First read-side input API in wdotool. Every command before this was a send-side virtual-pointer or virtual-keyboard call. `getmouselocation` reads the compositor's actual cursor position and prints it in xdotool's default format:

```
$ wdotool getmouselocation
x:842 y:391
```

Useful for scripts that want to remember and restore pointer position, or compose moves relative to the current spot. Closes the most-frequently-asked-about deferred row in `docs/xdotool-compat.md`.

## How it works

Two backends can read pointer position; three can't. The CLI handler asks the active backend and either prints the coordinates or exits 1 with a clear message naming the limitation.

KDE: generates a transient kwin script that reads `workspace.cursorPos` and calls back into the existing `com.wdotool.KdeBridge` D-Bus service via a new `ReportPointer` method. Same shape as the existing `list_windows` and `active_window` paths, just a different field. The script coerces with `(p.x | 0)` so callDBus sends i32 values matching the Bridge signature.

GNOME: the companion Shell extension at `packaging/gnome-extension/wdotool@wdotool.github.io/` grew a `GetPointerPosition` D-Bus method on `org.wdotool.GnomeShellBridge`. It calls `global.get_pointer()` and returns `(x, y)`. The third element of `global.get_pointer()` is a modifier mask, which we drop on purpose: wdotool exposes modifier reads through its own API (it doesn't, currently, but that's a separate question, not a side effect of this query).

The other three backends return `Ok(None)` from a default trait method on `Backend`. libei is send-only by design (EIS has no pointer-read path); wlroots' `zwlr_virtual_pointer_v1` is symmetrically send-only; uinput is at the kernel layer with no notion of "screen". The CLI's unsupported-backend message names each limitation and suggests `hyprctl cursorpos` or `swaymsg get_seats` as compositor IPC fallbacks for wlroots users.

## Capabilities surface

`Capabilities` struct grew a `pointer_position: bool`. The JSON Schema's `extras` object grew a `pointer_position` boolean. Adding an optional field to an existing object is backward-compat per the schema's own forward-compat rules, so this stays at `schema_version=1`. The npm package's `ExtrasCapabilities` type and test fixture both updated; CI catches drift between the schema and the TS types automatically.

## Important note for GNOME users

If you already have the wdotool Shell extension installed, you need to reinstall it from `packaging/gnome-extension/wdotool@wdotool.github.io/` to pick up the new `GetPointerPosition` method. Older copies will return a D-Bus error on `getmouselocation`. The CHANGELOG calls this out.

## What's not done

Real-hardware verification on KDE and GNOME. Both implementations compile, follow the same patterns the existing `list_windows` and `active_window` paths use on those backends, and route through machinery that's already exercised in the wild on a Plasma session per [issue #1](https://github.com/cushycush/wdotool/issues/1) tracking. But neither has been smoke-tested specifically for pointer reads on real hardware. The KDE smoke matrix at `docs/verification/kde-plasma-6.md` should grow a row for `getmouselocation` once a tester runs it.

## Test plan

53 Rust tests + 8 npm tests pass via `cargo test --workspace` and `npm test` from `packaging/npm/`. `cargo fmt` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean. Live-verified on Hyprland (wlroots): `wdotool getmouselocation` exits 1 with the expected stderr message, `wdotool capabilities` correctly emits `extras.pointer_position: false` for the wlroots backend.