### PR TITLE
docs: honest status table for KDE + GNOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For comparison with the alternatives: **xdotool** is X11-only and does not work 
 
 ## Status
 
-Early but usable. Actively tested on Hyprland + wlroots. The KDE and GNOME backends need help from people running those desktops to verify. If you have Plasma 6 hardware (laptop, dual-boot, loaner), the smoke-test checklist at [`docs/verification/kde-plasma-6.md`](docs/verification/kde-plasma-6.md) takes about 30 to 45 minutes; filling it in closes [issue #1](https://github.com/cushycush/wdotool/issues/1). The same kind of doc for GNOME ([issue #2](https://github.com/cushycush/wdotool/issues/2)) will land alongside or after KDE verification finishes.
+Early but usable. Actively tested on Hyprland + wlroots. The KDE and GNOME backends are both experimental: code paths compile and unit tests pass, but neither has been smoke-tested end-to-end on real hardware of the target desktop yet. If you run Plasma 6, [issue #1](https://github.com/cushycush/wdotool/issues/1) tracks verification — `docs/verification/kde-plasma-6.md` is a 30–45 minute checklist that closes it. Same shape for GNOME at [issue #4](https://github.com/cushycush/wdotool/issues/4).
 
 | Feature                         | libei    | wlroots | kde       | gnome     | uinput   |
 | ------------------------------- | -------- | ------- | --------- | --------- | -------- |
@@ -26,16 +26,17 @@ Early but usable. Actively tested on Hyprland + wlroots. The KDE and GNOME backe
 | `mousemove` (absolute)          | ✅       | ✅      | ✅        | ✅        | ✅       |
 | `click` / `mousedown` / `mouseup` | ✅     | ✅      | ✅        | ✅        | ✅       |
 | `scroll`                        | ✅       | ✅      | ✅        | ✅        | ✅       |
-| `search` / `getactivewindow`    | —        | ✅      | ✅³       | 🧪⁴       | —        |
-| `windowactivate` / `windowclose` | —       | ✅      | ✅³       | 🧪⁴       | —        |
+| `search` / `getactivewindow`    | —        | ✅      | 🧪³       | 🧪⁴       | —        |
+| `windowactivate` / `windowclose` | —       | ✅      | 🧪³       | 🧪⁴       | —        |
+| `getmouselocation`              | —        | —       | 🧪³       | 🧪⁴       | —        |
 
 ¹ libei (and `kde` / `gnome`, which use libei for input) is a sender context; the EIS server owns the keymap. Characters not in the active layout are skipped with a warning.
 
 ² uinput has the same limitation as libei — the kernel doesn't know about keymaps. Best-effort via the env-default xkb layout.
 
-³ Implemented but unverified on a real Plasma session ([issue #1](https://github.com/cushycush/wdotool/issues/1)).
+³ Implemented but unverified on a real Plasma session. The KDE backend uses kwin scripting over D-Bus the same way `kdotool` does; same machinery for `getmouselocation` reads `workspace.cursorPos`. [Issue #1](https://github.com/cushycush/wdotool/issues/1) tracks verification.
 
-⁴ Requires the companion GNOME Shell extension at `packaging/gnome-extension/wdotool@wdotool.github.io/`. Shipped in v0.1.6 but not yet smoke-tested on a real GNOME session; if you run GNOME, please try it and file [issue #2](https://github.com/cushycush/wdotool/issues/2) if anything breaks. Without the extension, `gnome` falls back to bare libei (input only).
+⁴ Requires the companion GNOME Shell extension at `packaging/gnome-extension/wdotool@wdotool.github.io/`. Shipped in v0.1.6 (window ops) and extended in v0.3.x (`GetPointerPosition`); not yet smoke-tested on a real GNOME session. [Issue #4](https://github.com/cushycush/wdotool/issues/4) tracks verification. Without the extension, `gnome` falls back to bare libei (input only).
 
 ## Install
 


### PR DESCRIPTION
## What this fixes

The Status table was claiming KDE was a confident green checkmark with a "but actually unverified" footnote, while GNOME was marked experimental with the same caveat. That asymmetry doesn't reflect reality: both backends have compiled code paths and unit tests but neither has been run on real hardware of the target desktop. They're the same risk profile, they should look the same in the table.

The footnotes were also pointing at closed issues. Footnote 3 linked to issue #1, which had been closed administratively without verification ever happening (no comments on the issue, no PR that proved anything ran). Footnote 4 linked to issue #2, which was actually about *shipping* the GNOME extension (done in v0.1.6) — the live verification tracker is issue #4.

## What ships

KDE row flips from `✅³` to `🧪³`. Footnote 3 retargets to issue #1, which I reopened in the issue tracker with a comment explaining the closure was administrative and that closing it for real should be tied to a filled-in row in `docs/verification/kde-plasma-6.md`.

Footnote 4 retargets from closed issue #2 to live issue #4.

Status preamble rewritten to drop the narrative that KDE was the next thing to verify and GNOME would follow. Both are equally unverified; both have a smoke-test issue tracking the work.

Bonus: added a `getmouselocation` row, which shipped in v0.3.x (#20) but wasn't represented in the status table. KDE and GNOME can read pointer position via kwin script and the Shell extension respectively; libei / wlroots / uinput can't, since the relevant Wayland protocols are send-only.

## Test plan

Pure docs change. Markdown render verified locally; the new table column count matches the existing rows.