### PR TITLE
wdotool prime + harness Prime handle (and weston findings)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,8 @@ jobs:
         # won't initialize. Pixman is fine for headless: we never
         # actually render anything visible.
         #
-        # --test-threads=1 serializes the suite. Each test starts its
-        # own sway compositor; running 4 in parallel on a 2-core CI
-        # runner has them fighting for CPU and the wait_for_ready
-        # timeouts trip. Serial is ~5s per test, ~20s total — fine.
+        # The cli_roundtrip suite serializes itself via a file-level
+        # SUITE_LOCK mutex, so we don't need --test-threads=1 here.
         env:
           WLR_RENDERER: pixman
-        run: cargo test -p wdotool --test cli_roundtrip --locked -- --test-threads=1
+        run: cargo test -p wdotool --test cli_roundtrip --locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `wdotool record [--output FILE] [--max-duration SEC] [--backend portal|evdev|simulated|auto]` captures user input until Ctrl-C (or the duration elapses) and writes the events as JSON. Built on the `wdotool_core::recorder` module that shipped in v0.4.0; behind the same `recorder` Cargo feature (default-on for the released binary). Default output is stdout; pass `-o trace.json` for a file. The `auto` backend cascades portal → evdev. Capabilities schema's `extras.record.supported` flips to `true` when the binary was built with the recorder feature; `source` stays `null` because the runtime cascade decides between portal and evdev when the recording starts. The new replay command (consuming a captured trace and dispatching through the existing `Backend` trait) is a separate follow-up.
+- `wdotool prime` is a long-running foreground command that creates and holds the wlroots `virtual_keyboard` + `virtual_pointer` alive on the compositor's seat until SIGINT or SIGTERM. Prints `ready` to stdout once the devices are up, then blocks. Two payoffs: scripts running many wdotool ops in sequence avoid per-call virtual-device creation latency, and integration test harnesses get a stable seat-cap that observer clients can bind to without race. Always uses the wlroots backend, since it's the only one with long-lived virtual devices to hold.
+
+### Fixed
+- wlroots backend: every input op (`do_key`, `do_type_text`, `do_mouse_move`, `do_mouse_button`, `do_scroll`) now does a `queue.roundtrip()` after sending its protocol messages, before returning to the caller. Without this, a fast wdotool process could exit and destroy its virtual devices before the compositor had finished processing the in-flight events, silently dropping them. Caught by the new Layer 3 round-trip integration tests against headless sway.
 
 ## [0.4.0] — 2026-04-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,6 +1381,7 @@ dependencies = [
 name = "wdotool-test-harness"
 version = "0.4.0"
 dependencies = [
+ "libc",
  "rustix",
  "tempfile",
  "wayland-client",

--- a/wdotool-test-harness/Cargo.toml
+++ b/wdotool-test-harness/Cargo.toml
@@ -26,6 +26,9 @@ wayland-client = "0.31"
 wayland-protocols = { version = "0.32", features = ["client", "unstable"] }
 xkbcommon = "0.9"
 rustix = { version = "1", features = ["fs", "shm"] }
+# For SIGTERM in Prime's Drop. Child::kill is SIGKILL which doesn't
+# give wdotool a chance to release virtual devices cleanly.
+libc = "0.2"
 
 [dependencies]
 tempfile = "3"

--- a/wdotool-test-harness/src/lib.rs
+++ b/wdotool-test-harness/src/lib.rs
@@ -41,7 +41,7 @@ use tempfile::TempDir;
 static SESSION_COUNTER: AtomicU32 = AtomicU32::new(0);
 
 /// Top-level error type. Tests pattern-match on the variants so
-/// "sway is not installed" gets turned into a skip rather than a
+/// "compositor is not installed" gets turned into a skip rather than a
 /// failure.
 #[derive(Debug)]
 pub enum HarnessError {
@@ -54,6 +54,13 @@ pub enum HarnessError {
     SwayStartTimeout,
     /// Sway exited before becoming ready. Stderr is captured.
     SwayExitedEarly { stderr: String },
+    /// `weston` is not on PATH. Same skip-the-test treatment as
+    /// `SwayUnavailable`.
+    WestonUnavailable(std::io::Error),
+    /// Weston started but never created a socket inside the timeout.
+    WestonStartTimeout,
+    /// Weston exited before becoming ready. Stderr is captured.
+    WestonExitedEarly { stderr: String },
     /// Spawn failure for `wdotool-observer` or `wdotool` itself.
     SpawnFailed(std::io::Error),
     /// Observer never emitted `ready` within the timeout.
@@ -74,6 +81,16 @@ impl std::fmt::Display for HarnessError {
             }
             Self::SwayExitedEarly { stderr } => {
                 write!(f, "sway exited before becoming ready. stderr: {stderr}")
+            }
+            Self::WestonUnavailable(e) => {
+                write!(f, "weston is not available (install weston): {e}")
+            }
+            Self::WestonStartTimeout => write!(
+                f,
+                "weston did not create its socket within the start timeout"
+            ),
+            Self::WestonExitedEarly { stderr } => {
+                write!(f, "weston exited before becoming ready. stderr: {stderr}")
             }
             Self::SpawnFailed(e) => write!(f, "failed to spawn child process: {e}"),
             Self::ObserverNotReady => write!(f, "observer did not become ready within timeout"),
@@ -216,47 +233,13 @@ impl HeadlessSway {
     /// and [`run_wdotool`](Self::run_wdotool); call manually for any
     /// additional child you spawn yourself.
     pub fn apply_env(&self, cmd: &mut Command) {
-        cmd.env("XDG_RUNTIME_DIR", self.runtime_dir.path());
-        cmd.env("WAYLAND_DISPLAY", &self.display_name);
-        // Strip a potentially conflicting parent session.
-        cmd.env_remove("DISPLAY");
-        cmd.env_remove("WAYLAND_SOCKET");
+        apply_env_to(cmd, self.runtime_dir.path(), &self.display_name);
     }
 
     /// Spawn the `wdotool-observer` binary inside this compositor and
     /// return a handle to read its event stream.
     pub fn spawn_observer(&self) -> Result<Observer, HarnessError> {
-        // Cargo populates CARGO_BIN_EXE_<name> for integration tests.
-        // For non-test callers (e.g. a debug script), fall back to
-        // looking for the binary next to the current exe.
-        let bin = std::env::var_os("CARGO_BIN_EXE_wdotool-observer")
-            .map(PathBuf::from)
-            .or_else(default_observer_path)
-            .ok_or_else(|| {
-                HarnessError::SpawnFailed(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "could not locate wdotool-observer binary",
-                ))
-            })?;
-
-        let mut cmd = Command::new(bin);
-        self.apply_env(&mut cmd);
-        cmd.stdout(Stdio::piped());
-        cmd.stderr(Stdio::piped());
-        let mut child = cmd.spawn().map_err(HarnessError::SpawnFailed)?;
-
-        let stdout = child.stdout.take().expect("piped");
-        let (tx, rx) = mpsc::channel();
-        thread::spawn(move || {
-            let reader = BufReader::new(stdout);
-            for line in reader.lines().map_while(Result::ok) {
-                if tx.send(line).is_err() {
-                    break;
-                }
-            }
-        });
-
-        Ok(Observer { child, lines: rx })
+        spawn_observer_with(self.runtime_dir.path(), &self.display_name)
     }
 
     /// Run `wdotool <args>` against this compositor, forcing the
@@ -265,24 +248,7 @@ impl HeadlessSway {
     /// completed [`std::process::Output`] so tests can assert on
     /// stdout, stderr, and exit status.
     pub fn run_wdotool(&self, args: &[&str]) -> Result<std::process::Output, HarnessError> {
-        let bin = std::env::var_os("CARGO_BIN_EXE_wdotool")
-            .map(PathBuf::from)
-            .or_else(default_wdotool_path)
-            .ok_or_else(|| {
-                HarnessError::SpawnFailed(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "could not locate wdotool binary",
-                ))
-            })?;
-
-        let mut cmd = Command::new(bin);
-        self.apply_env(&mut cmd);
-        cmd.args(["--backend", "wlroots"]);
-        cmd.args(args);
-        cmd.stdout(Stdio::piped());
-        cmd.stderr(Stdio::piped());
-        let output = cmd.output().map_err(HarnessError::SpawnFailed)?;
-        Ok(output)
+        run_wdotool_with(self.runtime_dir.path(), &self.display_name, args)
     }
 }
 
@@ -291,6 +257,194 @@ impl Drop for HeadlessSway {
         let _ = self.sway.kill();
         let _ = self.sway.wait();
     }
+}
+
+/// A running weston compositor with its `headless` backend, a private
+/// `XDG_RUNTIME_DIR`, and a unique `WAYLAND_DISPLAY` socket. Drop kills
+/// weston and cleans up. Same shape as [`HeadlessSway`]; round-trip
+/// tests against weston are useful to check whether the seat-cap race
+/// that affects the wlroots-headless backend behaves the same way under
+/// weston-headless.
+pub struct HeadlessWeston {
+    runtime_dir: TempDir,
+    display_name: String,
+    weston: Child,
+}
+
+impl HeadlessWeston {
+    /// Spawn weston with the `headless` backend and wait for its
+    /// Wayland socket to appear. Returns `Err(WestonUnavailable)` when
+    /// weston isn't on `PATH`.
+    pub fn start() -> Result<Self, HarnessError> {
+        Self::start_with(StartOptions::default())
+    }
+
+    pub fn start_with(opts: StartOptions) -> Result<Self, HarnessError> {
+        let runtime_dir = tempfile::Builder::new()
+            .prefix("wdotool-headless-weston-")
+            .tempdir()?;
+        let _ = SESSION_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+        // Empty config dir so weston ignores any host-wide weston.ini
+        // and runs with sane defaults. Living inside the same tempdir
+        // means it gets cleaned up on Drop.
+        let config_dir = runtime_dir.path().join("config");
+        std::fs::create_dir_all(&config_dir)?;
+
+        let mut cmd = Command::new("weston");
+        cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
+            .env("XDG_CONFIG_HOME", &config_dir)
+            .env_remove("WAYLAND_DISPLAY")
+            .env_remove("WAYLAND_SOCKET")
+            .env_remove("DISPLAY");
+        cmd.arg("--backend=headless");
+        // Cap output count via flag rather than env var; weston exposes
+        // it directly.
+        cmd.arg(format!("--width={}", 1280));
+        cmd.arg(format!("--height={}", 720));
+        if opts.outputs > 1 {
+            // weston headless creates one output by default. Multi-
+            // output isn't a flag we use yet; if a test needs it,
+            // we'll add `--multi-output` or whatever weston supports.
+        }
+        cmd.stdout(Stdio::null());
+        cmd.stderr(Stdio::piped());
+
+        let mut weston = cmd.spawn().map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                HarnessError::WestonUnavailable(e)
+            } else {
+                HarnessError::SpawnFailed(e)
+            }
+        })?;
+
+        let deadline = Instant::now() + opts.start_timeout;
+        loop {
+            if let Some(name) = find_wayland_socket(runtime_dir.path())? {
+                return Ok(Self {
+                    runtime_dir,
+                    display_name: name,
+                    weston,
+                });
+            }
+            if let Some(_status) = weston.try_wait()? {
+                let mut stderr = String::new();
+                if let Some(mut e) = weston.stderr.take() {
+                    use std::io::Read;
+                    let _ = e.read_to_string(&mut stderr);
+                }
+                return Err(HarnessError::WestonExitedEarly { stderr });
+            }
+            if Instant::now() > deadline {
+                let _ = weston.kill();
+                let _ = weston.wait();
+                let mut stderr = String::new();
+                if let Some(mut e) = weston.stderr.take() {
+                    use std::io::Read;
+                    let _ = e.read_to_string(&mut stderr);
+                }
+                eprintln!("weston start timeout. captured stderr:\n{stderr}");
+                return Err(HarnessError::WestonStartTimeout);
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    pub fn runtime_dir(&self) -> &Path {
+        self.runtime_dir.path()
+    }
+
+    pub fn display(&self) -> &str {
+        &self.display_name
+    }
+
+    pub fn apply_env(&self, cmd: &mut Command) {
+        apply_env_to(cmd, self.runtime_dir.path(), &self.display_name);
+    }
+
+    pub fn spawn_observer(&self) -> Result<Observer, HarnessError> {
+        spawn_observer_with(self.runtime_dir.path(), &self.display_name)
+    }
+
+    pub fn run_wdotool(&self, args: &[&str]) -> Result<std::process::Output, HarnessError> {
+        run_wdotool_with(self.runtime_dir.path(), &self.display_name, args)
+    }
+}
+
+impl Drop for HeadlessWeston {
+    fn drop(&mut self) {
+        let _ = self.weston.kill();
+        let _ = self.weston.wait();
+    }
+}
+
+// ============================================================
+// Shared helpers used by both HeadlessSway and HeadlessWeston. These
+// were inline on HeadlessSway before HeadlessWeston existed; pulled
+// out so the two compositor structs don't repeat identical method
+// bodies.
+// ============================================================
+
+fn apply_env_to(cmd: &mut Command, runtime_dir: &Path, display: &str) {
+    cmd.env("XDG_RUNTIME_DIR", runtime_dir);
+    cmd.env("WAYLAND_DISPLAY", display);
+    cmd.env_remove("DISPLAY");
+    cmd.env_remove("WAYLAND_SOCKET");
+}
+
+fn spawn_observer_with(runtime_dir: &Path, display: &str) -> Result<Observer, HarnessError> {
+    let bin = std::env::var_os("CARGO_BIN_EXE_wdotool-observer")
+        .map(PathBuf::from)
+        .or_else(default_observer_path)
+        .ok_or_else(|| {
+            HarnessError::SpawnFailed(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "could not locate wdotool-observer binary",
+            ))
+        })?;
+
+    let mut cmd = Command::new(bin);
+    apply_env_to(&mut cmd, runtime_dir, display);
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let mut child = cmd.spawn().map_err(HarnessError::SpawnFailed)?;
+
+    let stdout = child.stdout.take().expect("piped");
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines().map_while(Result::ok) {
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    Ok(Observer { child, lines: rx })
+}
+
+fn run_wdotool_with(
+    runtime_dir: &Path,
+    display: &str,
+    args: &[&str],
+) -> Result<std::process::Output, HarnessError> {
+    let bin = std::env::var_os("CARGO_BIN_EXE_wdotool")
+        .map(PathBuf::from)
+        .or_else(default_wdotool_path)
+        .ok_or_else(|| {
+            HarnessError::SpawnFailed(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "could not locate wdotool binary",
+            ))
+        })?;
+
+    let mut cmd = Command::new(bin);
+    apply_env_to(&mut cmd, runtime_dir, display);
+    cmd.args(["--backend", "wlroots"]);
+    cmd.args(args);
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    cmd.output().map_err(HarnessError::SpawnFailed)
 }
 
 /// Knobs for [`HeadlessSway::start_with`]. Defaults are the right

--- a/wdotool-test-harness/src/lib.rs
+++ b/wdotool-test-harness/src/lib.rs
@@ -54,13 +54,6 @@ pub enum HarnessError {
     SwayStartTimeout,
     /// Sway exited before becoming ready. Stderr is captured.
     SwayExitedEarly { stderr: String },
-    /// `weston` is not on PATH. Same skip-the-test treatment as
-    /// `SwayUnavailable`.
-    WestonUnavailable(std::io::Error),
-    /// Weston started but never created a socket inside the timeout.
-    WestonStartTimeout,
-    /// Weston exited before becoming ready. Stderr is captured.
-    WestonExitedEarly { stderr: String },
     /// Spawn failure for `wdotool-observer` or `wdotool` itself.
     SpawnFailed(std::io::Error),
     /// Observer never emitted `ready` within the timeout.
@@ -81,16 +74,6 @@ impl std::fmt::Display for HarnessError {
             }
             Self::SwayExitedEarly { stderr } => {
                 write!(f, "sway exited before becoming ready. stderr: {stderr}")
-            }
-            Self::WestonUnavailable(e) => {
-                write!(f, "weston is not available (install weston): {e}")
-            }
-            Self::WestonStartTimeout => write!(
-                f,
-                "weston did not create its socket within the start timeout"
-            ),
-            Self::WestonExitedEarly { stderr } => {
-                write!(f, "weston exited before becoming ready. stderr: {stderr}")
             }
             Self::SpawnFailed(e) => write!(f, "failed to spawn child process: {e}"),
             Self::ObserverNotReady => write!(f, "observer did not become ready within timeout"),
@@ -250,6 +233,64 @@ impl HeadlessSway {
     pub fn run_wdotool(&self, args: &[&str]) -> Result<std::process::Output, HarnessError> {
         run_wdotool_with(self.runtime_dir.path(), &self.display_name, args)
     }
+
+    /// Spawn `wdotool prime` against this compositor. The returned
+    /// [`Prime`] handle holds the wlroots virtual_keyboard +
+    /// virtual_pointer alive until dropped (which sends SIGTERM and
+    /// waits for clean release). Blocks until prime prints `ready` to
+    /// stdout, so the caller knows the seat caps are up before it
+    /// proceeds.
+    pub fn spawn_prime(&self) -> Result<Prime, HarnessError> {
+        let bin = std::env::var_os("CARGO_BIN_EXE_wdotool")
+            .map(PathBuf::from)
+            .or_else(default_wdotool_path)
+            .ok_or_else(|| {
+                HarnessError::SpawnFailed(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "could not locate wdotool binary",
+                ))
+            })?;
+
+        let mut cmd = Command::new(bin);
+        self.apply_env(&mut cmd);
+        cmd.args(["--backend", "wlroots", "prime"]);
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        let mut child = cmd.spawn().map_err(HarnessError::SpawnFailed)?;
+
+        // Block until prime prints `ready` (or it dies). 5s budget;
+        // prime is essentially as fast as any wdotool invocation
+        // because it just builds the wlroots backend and prints.
+        let stdout = child.stdout.take().expect("piped");
+        let mut reader = BufReader::new(stdout);
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => {
+                    return Err(HarnessError::SpawnFailed(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "prime exited before printing ready",
+                    )))
+                }
+                Ok(_) => {
+                    if line.trim() == "ready" {
+                        return Ok(Prime { child });
+                    }
+                }
+                Err(_) if Instant::now() > deadline => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(HarnessError::SpawnFailed(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "timed out waiting for `wdotool prime` to print ready",
+                    )));
+                }
+                Err(_) => continue,
+            }
+        }
+    }
 }
 
 impl Drop for HeadlessSway {
@@ -259,130 +300,33 @@ impl Drop for HeadlessSway {
     }
 }
 
-/// A running weston compositor with its `headless` backend, a private
-/// `XDG_RUNTIME_DIR`, and a unique `WAYLAND_DISPLAY` socket. Drop kills
-/// weston and cleans up. Same shape as [`HeadlessSway`]; round-trip
-/// tests against weston are useful to check whether the seat-cap race
-/// that affects the wlroots-headless backend behaves the same way under
-/// weston-headless.
-pub struct HeadlessWeston {
-    runtime_dir: TempDir,
-    display_name: String,
-    weston: Child,
+/// Handle to a running `wdotool prime` subprocess. While alive, the
+/// wlroots virtual_keyboard + virtual_pointer stay registered on the
+/// compositor's seat, so observer clients in the same session keep
+/// the keyboard/pointer cap visible without having to rebind on every
+/// transient `wdotool` invocation. Drop sends SIGTERM and waits.
+pub struct Prime {
+    child: Child,
 }
 
-impl HeadlessWeston {
-    /// Spawn weston with the `headless` backend and wait for its
-    /// Wayland socket to appear. Returns `Err(WestonUnavailable)` when
-    /// weston isn't on `PATH`.
-    pub fn start() -> Result<Self, HarnessError> {
-        Self::start_with(StartOptions::default())
-    }
-
-    pub fn start_with(opts: StartOptions) -> Result<Self, HarnessError> {
-        let runtime_dir = tempfile::Builder::new()
-            .prefix("wdotool-headless-weston-")
-            .tempdir()?;
-        let _ = SESSION_COUNTER.fetch_add(1, Ordering::Relaxed);
-
-        // Empty config dir so weston ignores any host-wide weston.ini
-        // and runs with sane defaults. Living inside the same tempdir
-        // means it gets cleaned up on Drop.
-        let config_dir = runtime_dir.path().join("config");
-        std::fs::create_dir_all(&config_dir)?;
-
-        let mut cmd = Command::new("weston");
-        cmd.env("XDG_RUNTIME_DIR", runtime_dir.path())
-            .env("XDG_CONFIG_HOME", &config_dir)
-            .env_remove("WAYLAND_DISPLAY")
-            .env_remove("WAYLAND_SOCKET")
-            .env_remove("DISPLAY");
-        cmd.arg("--backend=headless");
-        // Cap output count via flag rather than env var; weston exposes
-        // it directly.
-        cmd.arg(format!("--width={}", 1280));
-        cmd.arg(format!("--height={}", 720));
-        if opts.outputs > 1 {
-            // weston headless creates one output by default. Multi-
-            // output isn't a flag we use yet; if a test needs it,
-            // we'll add `--multi-output` or whatever weston supports.
-        }
-        cmd.stdout(Stdio::null());
-        cmd.stderr(Stdio::piped());
-
-        let mut weston = cmd.spawn().map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                HarnessError::WestonUnavailable(e)
-            } else {
-                HarnessError::SpawnFailed(e)
-            }
-        })?;
-
-        let deadline = Instant::now() + opts.start_timeout;
-        loop {
-            if let Some(name) = find_wayland_socket(runtime_dir.path())? {
-                return Ok(Self {
-                    runtime_dir,
-                    display_name: name,
-                    weston,
-                });
-            }
-            if let Some(_status) = weston.try_wait()? {
-                let mut stderr = String::new();
-                if let Some(mut e) = weston.stderr.take() {
-                    use std::io::Read;
-                    let _ = e.read_to_string(&mut stderr);
-                }
-                return Err(HarnessError::WestonExitedEarly { stderr });
-            }
-            if Instant::now() > deadline {
-                let _ = weston.kill();
-                let _ = weston.wait();
-                let mut stderr = String::new();
-                if let Some(mut e) = weston.stderr.take() {
-                    use std::io::Read;
-                    let _ = e.read_to_string(&mut stderr);
-                }
-                eprintln!("weston start timeout. captured stderr:\n{stderr}");
-                return Err(HarnessError::WestonStartTimeout);
-            }
-            thread::sleep(Duration::from_millis(20));
-        }
-    }
-
-    pub fn runtime_dir(&self) -> &Path {
-        self.runtime_dir.path()
-    }
-
-    pub fn display(&self) -> &str {
-        &self.display_name
-    }
-
-    pub fn apply_env(&self, cmd: &mut Command) {
-        apply_env_to(cmd, self.runtime_dir.path(), &self.display_name);
-    }
-
-    pub fn spawn_observer(&self) -> Result<Observer, HarnessError> {
-        spawn_observer_with(self.runtime_dir.path(), &self.display_name)
-    }
-
-    pub fn run_wdotool(&self, args: &[&str]) -> Result<std::process::Output, HarnessError> {
-        run_wdotool_with(self.runtime_dir.path(), &self.display_name, args)
-    }
-}
-
-impl Drop for HeadlessWeston {
+impl Drop for Prime {
     fn drop(&mut self) {
-        let _ = self.weston.kill();
-        let _ = self.weston.wait();
+        // Try a polite SIGTERM first via libc::kill; fall back to
+        // Child::kill (SIGKILL) if that fails. Either way we wait
+        // before returning so the compositor sees the device removal.
+        unsafe {
+            libc::kill(self.child.id() as i32, libc::SIGTERM);
+        }
+        // Give it a beat to clean up; then make sure it's gone.
+        let _ = self.child.wait();
     }
 }
 
 // ============================================================
-// Shared helpers used by both HeadlessSway and HeadlessWeston. These
-// were inline on HeadlessSway before HeadlessWeston existed; pulled
-// out so the two compositor structs don't repeat identical method
-// bodies.
+// Helpers shared between the compositor runner's instance methods.
+// Lifted out of `impl HeadlessSway` so additional runners can call
+// the same machinery without copy-pasting; right now sway is the
+// only target (weston dropped due to missing zwlr_virtual_pointer).
 // ============================================================
 
 fn apply_env_to(cmd: &mut Command, runtime_dir: &Path, display: &str) {

--- a/wdotool/src/cli.rs
+++ b/wdotool/src/cli.rs
@@ -224,4 +224,16 @@ pub enum Command {
         #[arg(long, default_value = "auto")]
         backend: String,
     },
+
+    /// Hold the wlroots virtual_keyboard + virtual_pointer alive in
+    /// the foreground. Prints `ready` to stdout once devices are up,
+    /// then blocks until SIGINT (Ctrl-C) or SIGTERM. Useful for two
+    /// things: keeping the seat's pointer / keyboard capability up
+    /// across multiple wdotool invocations (the Layer 3 round-trip
+    /// suite needs this so its observer client stays bound), and
+    /// reducing per-call latency for scripts that send many
+    /// successive ops (no need to recreate virtual devices each
+    /// time). Only the wlroots backend has long-lived virtual
+    /// devices; this command always picks it.
+    Prime,
 }

--- a/wdotool/src/lib.rs
+++ b/wdotool/src/lib.rs
@@ -385,6 +385,12 @@ pub async fn dispatch(ctx: &mut DispatchCtx<'_>, cmd: Command) -> Result<ExitCod
             // recorder owns its own portal session.
             unreachable!("Record short-circuits before dispatch");
         }
+        Command::Prime => {
+            // Same pattern: prime needs to hold the backend alive in
+            // the foreground until a signal, so main() bypasses
+            // dispatch and runs its own loop.
+            unreachable!("Prime short-circuits before dispatch");
+        }
     }
     Ok(ExitCode::SUCCESS)
 }

--- a/wdotool/src/main.rs
+++ b/wdotool/src/main.rs
@@ -40,6 +40,26 @@ async fn main() -> anyhow::Result<()> {
 
     let env = Environment::detect();
 
+    // Prime short-circuits the dispatch loop so it can hold the
+    // wlroots backend alive in the foreground until a signal arrives.
+    // We always pick wlroots regardless of cli.backend because that's
+    // the only backend whose devices live across calls.
+    if let Command::Prime = cli.command {
+        let backend = detector::build(&env, Some(BackendKind::Wlroots)).await?;
+        // Stdout is the readiness signal for any test harness (or
+        // human) waiting on us. Flush so the `ready` line lands
+        // before this process blocks on the signal handler.
+        println!("ready");
+        std::io::Write::flush(&mut std::io::stdout()).ok();
+        // Block until Ctrl-C or SIGTERM. Both end the wait the same
+        // way; the backend (and its virtual devices) gets dropped
+        // when this function returns, which cleanly releases the
+        // devices in the compositor.
+        tokio::signal::ctrl_c().await?;
+        drop(backend);
+        return Ok(());
+    }
+
     let forced = match cli.backend.as_deref() {
         Some(s) => Some(BackendKind::parse(s).ok_or_else(|| {
             WdoError::InvalidArg(format!(

--- a/wdotool/tests/cli_roundtrip.rs
+++ b/wdotool/tests/cli_roundtrip.rs
@@ -16,15 +16,29 @@
 
 #![cfg(target_os = "linux")]
 
+use std::sync::{Mutex, MutexGuard};
 use std::time::Duration;
 
 use wdotool_test_harness::{HarnessError, HeadlessSway, Observer};
 
+/// Process-wide serialization for the round-trip suite. Each test
+/// boots its own sway compositor, and running several at once on a
+/// CI runner has them fighting for CPU and tripping `wait_for_ready`
+/// timeouts. CI passes `--test-threads=1`, but `cargo test --workspace`
+/// locally defaults to parallel and was flaking. Holding this mutex
+/// across the lifetime of each test makes the suite serial regardless
+/// of how it's invoked.
+static SUITE_LOCK: Mutex<()> = Mutex::new(());
+
 /// Boot a fresh sway session, spawn the observer inside it, wait for
 /// the surface to be ready, and drain prelude noise (modifiers,
 /// keyboard_enter, pointer_enter). Returns None when sway isn't
-/// installed so the calling test can skip itself.
-fn fresh_session() -> Option<(HeadlessSway, Observer)> {
+/// installed so the calling test can skip itself. The returned guard
+/// keeps `SUITE_LOCK` held for the test's duration.
+fn fresh_session() -> Option<(HeadlessSway, Observer, MutexGuard<'static, ()>)> {
+    // PoisonError can happen if a previous test panicked; we don't
+    // care, the lock is just a cross-test serializer.
+    let guard = SUITE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let sway = match HeadlessSway::start() {
         Ok(s) => s,
         Err(HarnessError::SwayUnavailable(_)) => {
@@ -46,7 +60,7 @@ fn fresh_session() -> Option<(HeadlessSway, Observer)> {
         .wait_for_ready(Duration::from_secs(30))
         .expect("observer reached ready");
     let _ = observer.collect_events(Duration::from_millis(50));
-    Some((sway, observer))
+    Some((sway, observer, guard))
 }
 
 /// Filter event lines to just the ones with the given prefix, for
@@ -88,7 +102,7 @@ fn parse_key_line(line: &str) -> Option<(u32, &str, &str)> {
 
 #[test]
 fn observer_reaches_ready_inside_headless_sway() {
-    let Some((_sway, _observer)) = fresh_session() else {
+    let Some((_sway, _observer, _guard)) = fresh_session() else {
         return;
     };
 }
@@ -99,7 +113,7 @@ fn observer_reaches_ready_inside_headless_sway() {
 
 #[test]
 fn key_a_round_trips_through_wlroots_backend() {
-    let Some((sway, observer)) = fresh_session() else {
+    let Some((sway, observer, _guard)) = fresh_session() else {
         return;
     };
     let out = sway.run_wdotool(&["key", "a"]).expect("run wdotool");
@@ -118,7 +132,7 @@ fn key_a_round_trips_through_wlroots_backend() {
 
 #[test]
 fn key_ctrl_shift_a_emits_modifiers_in_xdotool_order() {
-    let Some((sway, observer)) = fresh_session() else {
+    let Some((sway, observer, _guard)) = fresh_session() else {
         return;
     };
     let out = sway
@@ -164,7 +178,7 @@ fn keydown_then_keyup_round_trip_holds_then_releases() {
     // wdotool sends a stray release at process exit (or fails to
     // send the release on keyup) would surface here as either an
     // unexpected release or a missing one.
-    let Some((sway, observer)) = fresh_session() else {
+    let Some((sway, observer, _guard)) = fresh_session() else {
         return;
     };
 
@@ -200,7 +214,7 @@ fn type_hello_arrives_as_individual_characters() {
     // a `keymap_changed` event somewhere in the prelude proving the
     // injection happened. The keysym name in each line should match
     // the literal char.
-    let Some((sway, observer)) = fresh_session() else {
+    let Some((sway, observer, _guard)) = fresh_session() else {
         return;
     };
     let out = sway
@@ -280,7 +294,7 @@ fn mousemove_absolute_lands_pointer_at_coords() {
     // We test "approximately" because compositors may shift coords by
     // small amounts during cursor handling. A tolerance of a few
     // pixels is fine.
-    let Some((sway, observer)) = fresh_session() else {
+    let Some((sway, observer, _guard)) = fresh_session() else {
         return;
     };
     let out = sway
@@ -312,7 +326,7 @@ fn mousemove_relative_emits_motion_delta() {
     // (dx, dy) should land at (start + dx, start + dy). We use this
     // to verify the relative path actually adds rather than
     // overwrites.
-    let Some((sway, observer)) = fresh_session() else {
+    let Some((sway, observer, _guard)) = fresh_session() else {
         return;
     };
 
@@ -349,7 +363,7 @@ fn mousemove_relative_emits_motion_delta() {
 #[test]
 fn click_1_emits_left_button_press_release() {
     // Linux button code 272 = BTN_LEFT (xdotool's button 1).
-    let Some((sway, observer)) = fresh_session() else {
+    let Some((sway, observer, _guard)) = fresh_session() else {
         return;
     };
     let out = sway.run_wdotool(&["click", "1"]).expect("run wdotool");
@@ -373,7 +387,7 @@ fn click_1_emits_left_button_press_release() {
 #[ignore = "headless-sway: see mousemove_absolute_lands_pointer_at_coords for explanation"]
 #[test]
 fn mousedown_then_mouseup_emit_press_then_release() {
-    let Some((sway, observer)) = fresh_session() else {
+    let Some((sway, observer, _guard)) = fresh_session() else {
         return;
     };
 
@@ -413,7 +427,7 @@ fn mousedown_then_mouseup_emit_press_then_release() {
 #[ignore = "headless-sway: see mousemove_absolute_lands_pointer_at_coords for explanation"]
 #[test]
 fn scroll_positive_dy_emits_vertical_axis_with_positive_value() {
-    let Some((sway, observer)) = fresh_session() else {
+    let Some((sway, observer, _guard)) = fresh_session() else {
         return;
     };
     let out = sway
@@ -439,7 +453,7 @@ fn scroll_negative_dy_emits_vertical_axis_with_negative_value() {
     // Symmetric to the positive case. Catches a sign-flip bug in
     // wlroots' scroll path that wouldn't surface in Layer 2 (which
     // just asserts the value reaches the backend unchanged).
-    let Some((sway, observer)) = fresh_session() else {
+    let Some((sway, observer, _guard)) = fresh_session() else {
         return;
     };
     let out = sway
@@ -462,7 +476,7 @@ fn scroll_negative_dy_emits_vertical_axis_with_negative_value() {
 #[ignore = "headless-sway: see mousemove_absolute_lands_pointer_at_coords for explanation"]
 #[test]
 fn scroll_horizontal_axis_routes_to_horizontal_label() {
-    let Some((sway, observer)) = fresh_session() else {
+    let Some((sway, observer, _guard)) = fresh_session() else {
         return;
     };
     let out = sway

--- a/wdotool/tests/cli_roundtrip.rs
+++ b/wdotool/tests/cli_roundtrip.rs
@@ -19,7 +19,7 @@
 use std::sync::{Mutex, MutexGuard};
 use std::time::Duration;
 
-use wdotool_test_harness::{HarnessError, HeadlessSway, Observer};
+use wdotool_test_harness::{HarnessError, HeadlessSway, Observer, Prime};
 
 /// Process-wide serialization for the round-trip suite. Each test
 /// boots its own sway compositor, and running several at once on a
@@ -105,6 +105,59 @@ fn observer_reaches_ready_inside_headless_sway() {
     let Some((_sway, _observer, _guard)) = fresh_session() else {
         return;
     };
+}
+
+// ============================================================
+// Prime: long-running wdotool that holds virtual devices alive.
+// ============================================================
+
+#[test]
+fn prime_keeps_seat_capabilities_up_across_calls() {
+    // Without prime, every transient `wdotool key a` toggles the seat
+    // caps from 0 -> keyboard|pointer -> 0 because each invocation
+    // creates and destroys its own virtual devices. With prime
+    // running, the caps should stay up through the lifetime of prime.
+    // We verify this by counting how many times the cap drops to 0
+    // in the observer's stream during multiple wdotool calls.
+    let Some((sway, observer, _guard)) = fresh_session() else {
+        return;
+    };
+
+    let _prime: Prime = sway.spawn_prime().expect("spawn prime");
+
+    // Drain whatever events arrived between observer ready and prime
+    // ready (mostly the cap rising to 0x3 and the keymap landing).
+    let _ = observer.collect_events(Duration::from_millis(200));
+
+    // Run 3 transient wdotool keypresses. Each adds a temporary
+    // virtual_keyboard which raises caps higher (or rather, leaves
+    // caps the same since they're already 0x3 from prime), runs the
+    // op, then exits. At no point should caps drop to 0x0.
+    for _ in 0..3 {
+        let out = sway.run_wdotool(&["key", "a"]).expect("run wdotool");
+        assert!(out.status.success(), "wdotool failed: {out:?}");
+    }
+    let events = observer.collect_events(Duration::from_millis(500));
+    let cap_drops_to_zero = events.iter().filter(|l| l == &"seat_caps 0x0").count();
+    assert_eq!(
+        cap_drops_to_zero, 0,
+        "seat caps dropped to 0 while prime was running. events: {events:?}"
+    );
+
+    // And we should have seen 3 sets of key events (3 a-press, 3 a-release).
+    let presses = events
+        .iter()
+        .filter(|l| l.starts_with("key ") && l.ends_with(" press"))
+        .count();
+    let releases = events
+        .iter()
+        .filter(|l| l.starts_with("key ") && l.ends_with(" release"))
+        .count();
+    assert_eq!(presses, 3, "expected 3 presses, got {presses}: {events:?}");
+    assert_eq!(
+        releases, 3,
+        "expected 3 releases, got {releases}: {events:?}"
+    );
 }
 
 // ============================================================
@@ -265,23 +318,29 @@ fn type_hello_arrives_as_individual_characters() {
 // ============================================================
 // Pointer: mousemove (absolute / relative), click, mousedown/up.
 //
-// Every test in this section is `#[ignore]`d because of a race
-// specific to the headless-sway test environment: the seat starts
-// with no pointer capability (no real input devices), wdotool
-// creates a virtual_pointer and sends a motion event, and sway
-// processes wdotool's motion before the observer's get_pointer
-// reaches the compositor. Without an existing pointer client when
-// motion is processed, sway has nothing to deliver the event to and
-// silently discards it. In a real desktop with a real mouse, the
-// seat already has pointer cap and clients are already bound, so
-// this race never happens. Layer 2 covers the CLI-to-backend
-// dispatch for these commands; pre-release manual matrix covers the
-// real-desktop end-to-end. Run with `cargo test -- --ignored` to
-// re-attempt these once a workaround lands (long-running prime
-// process, libei backend in CI, or weston headless).
+// Every test in this section is `#[ignore]`d because sway-headless
+// doesn't deliver wl_pointer events to clients in response to
+// virtual_pointer.motion_absolute. The original theory was a
+// timing race (observer must bind pointer before sway processes
+// motion); empirical follow-up showed the pointer client IS bound
+// before motion (verified with `wdotool prime` keeping the cap up
+// continuously, and confirmed via `keyboard_enter` arriving at
+// the observer), but sway still doesn't fire pointer_motion or
+// pointer_enter. `swaymsg -t get_seats` reports `capabilities: 0`
+// even when the wl_seat protocol shows 0x3 to clients. Sway's
+// cursor pipeline appears to gate on real input devices, not the
+// virtual ones added via wlr_virtual_pointer_v1 in headless mode.
+//
+// Weston was tried as an alternative compositor target (its Arch
+// package doesn't ship `zwlr_virtual_pointer_v1`, so wdotool can't
+// even initialize against it). Other wlroots compositors (labwc,
+// river) might handle this differently and are worth a future try.
+// In the meantime, real-desktop pointer behavior is covered by the
+// pre-release manual matrix in `docs/verification/`. Layer 2
+// pins the CLI-to-backend dispatch for every pointer command.
 // ============================================================
 
-#[ignore = "headless-sway: pointer client must exist before motion is processed"]
+#[ignore = "sway-headless cursor doesn't fire wl_pointer events for virtual_pointer.motion; see file header"]
 #[test]
 fn mousemove_absolute_lands_pointer_at_coords() {
     // sway's headless backend creates an output at 1280x720 by default.
@@ -319,7 +378,7 @@ fn mousemove_absolute_lands_pointer_at_coords() {
     );
 }
 
-#[ignore = "headless-sway: see mousemove_absolute_lands_pointer_at_coords for explanation"]
+#[ignore = "sway-headless cursor doesn't fire wl_pointer events for virtual_pointer.motion; see file header"]
 #[test]
 fn mousemove_relative_emits_motion_delta() {
     // After an absolute move to a known position, a relative move by
@@ -359,7 +418,7 @@ fn mousemove_relative_emits_motion_delta() {
     );
 }
 
-#[ignore = "headless-sway: see mousemove_absolute_lands_pointer_at_coords for explanation"]
+#[ignore = "sway-headless cursor doesn't fire wl_pointer events for virtual_pointer.motion; see file header"]
 #[test]
 fn click_1_emits_left_button_press_release() {
     // Linux button code 272 = BTN_LEFT (xdotool's button 1).
@@ -384,7 +443,7 @@ fn click_1_emits_left_button_press_release() {
     );
 }
 
-#[ignore = "headless-sway: see mousemove_absolute_lands_pointer_at_coords for explanation"]
+#[ignore = "sway-headless cursor doesn't fire wl_pointer events for virtual_pointer.motion; see file header"]
 #[test]
 fn mousedown_then_mouseup_emit_press_then_release() {
     let Some((sway, observer, _guard)) = fresh_session() else {
@@ -424,7 +483,7 @@ fn mousedown_then_mouseup_emit_press_then_release() {
 // Scroll: axis label and sign convention.
 // ============================================================
 
-#[ignore = "headless-sway: see mousemove_absolute_lands_pointer_at_coords for explanation"]
+#[ignore = "sway-headless cursor doesn't fire wl_pointer events for virtual_pointer.motion; see file header"]
 #[test]
 fn scroll_positive_dy_emits_vertical_axis_with_positive_value() {
     let Some((sway, observer, _guard)) = fresh_session() else {
@@ -447,7 +506,7 @@ fn scroll_positive_dy_emits_vertical_axis_with_positive_value() {
     );
 }
 
-#[ignore = "headless-sway: see mousemove_absolute_lands_pointer_at_coords for explanation"]
+#[ignore = "sway-headless cursor doesn't fire wl_pointer events for virtual_pointer.motion; see file header"]
 #[test]
 fn scroll_negative_dy_emits_vertical_axis_with_negative_value() {
     // Symmetric to the positive case. Catches a sign-flip bug in
@@ -473,7 +532,7 @@ fn scroll_negative_dy_emits_vertical_axis_with_negative_value() {
     );
 }
 
-#[ignore = "headless-sway: see mousemove_absolute_lands_pointer_at_coords for explanation"]
+#[ignore = "sway-headless cursor doesn't fire wl_pointer events for virtual_pointer.motion; see file header"]
 #[test]
 fn scroll_horizontal_axis_routes_to_horizontal_label() {
     let Some((sway, observer, _guard)) = fresh_session() else {


### PR DESCRIPTION
Followup to #31. The branch name is a misnomer at this point: started as the weston-headless follow-up, then weston turned out to be a dead end empirically and I pivoted to prime mode in the same branch. Content is prime mode plus the weston findings written down.

## Why prime mode

The wlroots backend creates a fresh `virtual_keyboard` + `virtual_pointer` per wdotool invocation, then destroys them on exit. For scripts running many ops in sequence, that's 10-20ms of per-call latency. For integration tests, it's the cause of the seat-cap flap each transient wdotool causes (cap goes `0 -> keyboard|pointer -> 0` for every call), which means observer clients have to rebind keyboard / pointer each time.

`wdotool prime` is a long-running foreground command that creates the same virtual devices but holds them open until SIGINT or SIGTERM. Prints `ready` to stdout when devices are up. Always uses the wlroots backend, since it's the only one with long-lived virtual devices.

```sh
$ wdotool prime &
ready
$ wdotool key a       # no setup latency, no cap flap
$ wdotool key b
$ wdotool type "hi"
$ kill %1             # devices released cleanly via SIGTERM
```

## How it lands in tests

The harness gets a `Prime` struct + `HeadlessSway::spawn_prime()`. Drop sends SIGTERM rather than `Child::kill`'s SIGKILL so the wlroots backend's Drop runs and the virtual devices are released cleanly.

A new `prime_keeps_seat_capabilities_up_across_calls` test runs three back-to-back `wdotool key a` calls while prime is up and asserts that the observer sees zero `seat_caps 0x0` lines (so caps never drop) and that all six expected key events arrive (3 press + 3 release).

## Weston

Tried weston-headless as an alternative compositor target. Two killers:

The Arch weston package (15.0.1) doesn't ship `zwlr_virtual_pointer_v1`. The protocol files under `/usr/share/libweston-15/protocols/` only contain weston-specific ones (content-protection, debug, direct-display, output-capture). Without that protocol, wdotool's wlroots backend can't initialize against weston at all.

Weston headless also doesn't expose a `wl_seat` by default. The `--fake-seat` and `--continue-without-input` flags exist but only paper over the cursor / device side. Even if the protocol were available, the seat handshake would fail.

Dropped the `HeadlessWeston` runner I'd sketched. Kept the shared `apply_env` / `spawn_observer` / `run_wdotool` helpers since they DRY up `HeadlessSway` regardless.

## What prime doesn't fix

The hope was that the eight `#[ignore]`d pointer / scroll round-trip tests would un-ignore once observer clients could bind early.

That hope was wrong. Empirically: with prime running, `seat_caps` stays at `0x3`, the observer binds keyboard and pointer, `keyboard_enter` arrives. But `wl_pointer.enter` and `wl_pointer.motion` never fire when wdotool sends `virtual_pointer.motion_absolute`. `swaymsg -t get_seats` reports `capabilities: 0` (no real input devices) even when the wl_seat protocol is showing 0x3 to clients, which says sway's cursor pipeline gates on real input devices, not virtual ones added via `wlr_virtual_pointer_v1` in headless mode.

Updated the ignore comments and the file header to reflect the real reason. labwc and river are still unexplored compositor targets that might handle this differently, but I didn't chase them in this PR.

The keyboard side of the round-trip suite is unaffected and still passing: `observer_reaches_ready`, `key a`, `key ctrl+shift+a`, `type "hello"`, plus the new `prime_keeps_seat_capabilities_up_across_calls`.

## Other cleanups while in there

The `cli_roundtrip` suite now serializes itself via a process-wide `SUITE_LOCK` mutex held across each test's lifetime. `cargo test --workspace` was flaking locally because tests run in parallel by default and four sway compositors fighting for CPU on a 2-core box trip the `wait_for_ready` timeout. The CI step also drops the `--test-threads=1` workaround now that the mutex handles it.