### PR TITLE
fix: multi-output mousemove --output places cursor on the right monitor (#22)

### DIFF
--- a/wdotool-core/src/backend/mod.rs
+++ b/wdotool-core/src/backend/mod.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 
-use crate::error::Result;
+use crate::error::{Result, WdoError};
 use crate::types::{
     Capabilities, KeyDirection, MouseButton, OutputInfo, WindowGeometry, WindowId, WindowInfo,
 };
@@ -34,6 +34,37 @@ pub trait Backend: Send + Sync {
     async fn mouse_move(&self, x: i32, y: i32, absolute: bool) -> Result<()>;
     async fn mouse_button(&self, btn: MouseButton, dir: KeyDirection) -> Result<()>;
     async fn scroll(&self, dx: f64, dy: f64) -> Result<()>;
+
+    /// Move the pointer to `(x, y)` interpreted as output-local
+    /// coordinates within the named output. The default implementation
+    /// looks up the output's origin via [`list_outputs`], translates
+    /// to global compositor coords, and falls through to
+    /// [`mouse_move`] with `absolute = true`. The wlroots backend
+    /// overrides this to bind a per-output `virtual_pointer` and send
+    /// `motion_absolute` against that output's mode dimensions
+    /// directly, since wlroots' single-pointer `motion_absolute` ties
+    /// the extent to the primary output (placing the cursor on the
+    /// wrong monitor for non-primary `--output` calls).
+    ///
+    /// [`list_outputs`]: Backend::list_outputs
+    /// [`mouse_move`]: Backend::mouse_move
+    async fn mouse_move_to_output(&self, output: &str, x: i32, y: i32) -> Result<()> {
+        let outputs = self.list_outputs().await?;
+        if outputs.is_empty() {
+            return Err(WdoError::InvalidArg(format!(
+                "--output not supported: the {} backend does not enumerate outputs",
+                self.name()
+            )));
+        }
+        let target = outputs.iter().find(|o| o.name == output).ok_or_else(|| {
+            let available: Vec<&str> = outputs.iter().map(|o| o.name.as_str()).collect();
+            WdoError::InvalidArg(format!(
+                "no output named {output:?}; available: {}",
+                available.join(", ")
+            ))
+        })?;
+        self.mouse_move(target.x + x, target.y + y, true).await
+    }
 
     async fn list_windows(&self) -> Result<Vec<WindowInfo>>;
     async fn active_window(&self) -> Result<Option<WindowInfo>>;

--- a/wdotool-core/src/backend/wlroots.rs
+++ b/wdotool-core/src/backend/wlroots.rs
@@ -131,6 +131,17 @@ enum Command {
         absolute: bool,
         reply: oneshot::Sender<Result<()>>,
     },
+    /// Move pointer using a per-output `virtual_pointer` bound to the
+    /// named output. The worker looks up (or lazily creates) the
+    /// per-output instance and sends `motion_absolute` against that
+    /// output's mode dimensions, so the cursor lands on the right
+    /// monitor regardless of which output is "primary".
+    MouseMoveToOutput {
+        output: String,
+        x: i32,
+        y: i32,
+        reply: oneshot::Sender<Result<()>>,
+    },
     MouseButton {
         btn: MouseButton,
         dir: KeyDirection,
@@ -375,6 +386,14 @@ fn worker_main(
     // threaded loop), so a plain u32 suffices.
     let mut mods_depressed: u32 = 0;
 
+    // Cache of per-output virtual_pointer instances. Built lazily on
+    // the first `mousemove --output <name>` call for each output;
+    // reused on subsequent calls. Keyed by output name (e.g. "DP-1").
+    // The default `vp_obj` (created above without an output binding)
+    // is what `mousemove` without --output uses; this cache only
+    // serves the per-output path. Closes #22.
+    let mut output_pointers: HashMap<String, vp::ZwlrVirtualPointerV1> = HashMap::new();
+
     // Command loop. Each command is followed by a short dispatch to drain
     // events that arrived in response (e.g., foreign-toplevel updates).
     loop {
@@ -425,6 +444,27 @@ fn worker_main(
                 // destruction past the motion request and the
                 // compositor silently discards it (caught via the
                 // headless-sway integration tests).
+                let _ = queue.roundtrip(&mut state);
+                let _ = reply.send(res);
+            }
+            Command::MouseMoveToOutput {
+                output,
+                x,
+                y,
+                reply,
+            } => {
+                let _ = queue.dispatch_pending(&mut state);
+                let res = do_mouse_move_to_output(
+                    &conn,
+                    &qh,
+                    &state,
+                    state.scratch.vp_mgr.as_ref(),
+                    state.scratch.seat.as_ref(),
+                    &mut output_pointers,
+                    &output,
+                    x,
+                    y,
+                );
                 let _ = queue.roundtrip(&mut state);
                 let _ = reply.send(res);
             }
@@ -761,6 +801,83 @@ fn do_mouse_move(
     } else {
         vp.motion(time, x as f64, y as f64);
     }
+    vp.frame();
+    conn.flush().map_err(wayland_io_err)?;
+    Ok(())
+}
+
+/// Per-output `motion_absolute`. Looks up (or lazily creates) a
+/// `virtual_pointer` bound to the named output via
+/// `create_virtual_pointer_with_output`, then sends `motion_absolute`
+/// against that output's mode dimensions. Without this, `mousemove
+/// --output DP-2 50 50` hits the wrong monitor because wlroots' default
+/// single-pointer interprets the extent against the primary output.
+/// Closes #22.
+#[allow(clippy::too_many_arguments)]
+fn do_mouse_move_to_output(
+    conn: &Connection,
+    qh: &QueueHandle<State>,
+    state: &State,
+    vp_mgr: Option<&vp_mgr::ZwlrVirtualPointerManagerV1>,
+    seat: Option<&wl_seat::WlSeat>,
+    output_pointers: &mut HashMap<String, vp::ZwlrVirtualPointerV1>,
+    output_name: &str,
+    x: i32,
+    y: i32,
+) -> Result<()> {
+    let vp_mgr = vp_mgr.ok_or(WdoError::NotSupported {
+        backend: NAME,
+        what:
+            "compositor does not expose zwlr_virtual_pointer_v1. Try --backend libei on GNOME/KDE",
+    })?;
+    let seat = seat.ok_or(WdoError::Backend {
+        backend: NAME,
+        source: "no wl_seat available".into(),
+    })?;
+
+    // Find the matching output's wl_output proxy + mode dimensions.
+    let target = state
+        .outputs
+        .values()
+        .find(|s| s.name.as_deref() == Some(output_name))
+        .ok_or_else(|| {
+            let available: Vec<&str> = state
+                .outputs
+                .values()
+                .filter_map(|s| s.name.as_deref())
+                .collect();
+            WdoError::InvalidArg(format!(
+                "no output named {output_name:?}; available: {}",
+                available.join(", ")
+            ))
+        })?;
+    let proxy = target.proxy.as_ref().ok_or_else(|| WdoError::Backend {
+        backend: NAME,
+        source: format!("output {output_name} has no wl_output proxy").into(),
+    })?;
+    if target.width == 0 || target.height == 0 {
+        return Err(WdoError::Backend {
+            backend: NAME,
+            source: format!("output {output_name} has no mode dimensions yet").into(),
+        });
+    }
+
+    // Lazily create the per-output virtual_pointer on first use, then
+    // cache it for the lifetime of the worker. The vp_obj is a fresh
+    // proxy each time we call create_virtual_pointer_with_output, so
+    // we reuse a single instance per output to avoid leaking proxies.
+    let vp = output_pointers
+        .entry(output_name.to_string())
+        .or_insert_with(|| {
+            vp_mgr.create_virtual_pointer_with_output(Some(seat), Some(proxy), qh, ())
+        });
+
+    let time = millis_monotonic();
+    let x_extent = target.width;
+    let y_extent = target.height;
+    let xc = x.clamp(0, x_extent as i32) as u32;
+    let yc = y.clamp(0, y_extent as i32) as u32;
+    vp.motion_absolute(time, xc, yc, x_extent, y_extent);
     vp.frame();
     conn.flush().map_err(wayland_io_err)?;
     Ok(())
@@ -1431,6 +1548,17 @@ impl Backend for WlrootsBackend {
             x,
             y,
             absolute,
+            reply,
+        })
+        .await
+    }
+
+    async fn mouse_move_to_output(&self, output: &str, x: i32, y: i32) -> Result<()> {
+        let output = output.to_string();
+        self.send(|reply| Command::MouseMoveToOutput {
+            output,
+            x,
+            y,
             reply,
         })
         .await

--- a/wdotool/src/lib.rs
+++ b/wdotool/src/lib.rs
@@ -182,33 +182,17 @@ pub async fn dispatch(ctx: &mut DispatchCtx<'_>, cmd: Command) -> Result<ExitCod
             x,
             y,
         } => {
-            // --output translates output-local coordinates to global
-            // before calling mouse_move_absolute. clap already rejects
-            // --output combined with --relative.
-            let (target_x, target_y) = match output {
-                Some(name) => {
-                    let outputs = ctx.backend.list_outputs().await?;
-                    if outputs.is_empty() {
-                        return Err(WdoError::InvalidArg(format!(
-                            "--output not supported: the {} backend does not enumerate outputs",
-                            ctx.backend.name()
-                        )));
-                    }
-                    let target = outputs.iter().find(|o| o.name == name).ok_or_else(|| {
-                        let available: Vec<&str> =
-                            outputs.iter().map(|o| o.name.as_str()).collect();
-                        WdoError::InvalidArg(format!(
-                            "no output named {name:?}; available: {}",
-                            available.join(", ")
-                        ))
-                    })?;
-                    (target.x + x, target.y + y)
-                }
-                None => (x, y),
-            };
-            ctx.backend
-                .mouse_move(target_x, target_y, !relative)
-                .await?;
+            // clap already rejects --output combined with --relative,
+            // so the two arms here are mutually exclusive. The
+            // --output path delegates to the trait's
+            // mouse_move_to_output method, which has a default impl
+            // that translates output-local coords to global; the
+            // wlroots backend overrides that default to bind a
+            // per-output virtual_pointer (fixes #22).
+            match output {
+                Some(name) => ctx.backend.mouse_move_to_output(&name, x, y).await?,
+                None => ctx.backend.mouse_move(x, y, !relative).await?,
+            }
         }
         Command::Click { button } => {
             ctx.backend


### PR DESCRIPTION
Closes #22. The bug: `wdotool mousemove --output DP-2 50 50` correctly translated the user's coords by adding DP-2's logical-position offset, but the wlroots `virtual_pointer.motion_absolute` request interprets coords against the *primary* output's mode dimensions, not the bound output's. So on multi-monitor setups the cursor would land on the primary output even when --output named a secondary one.

## Fix shape

The Backend trait gains `mouse_move_to_output(output, x, y)` with a default implementation that mirrors today's dispatch behavior: look up the output, translate to global, call `mouse_move` with `absolute = true`. Most backends inherit the default and behave exactly as before.

The wlroots backend overrides it to use `create_virtual_pointer_with_output`, which binds a per-output `virtual_pointer` instance. Its `motion_absolute` is interpreted against the bound output's mode dimensions, so the cursor lands on the right monitor. Per-output instances are cached on the worker by output name; subsequent calls reuse the same `virtual_pointer`.

Dispatch in `wdotool/src/lib.rs` shrinks to a single trait call: when `--output` is set, route through `mouse_move_to_output`; otherwise the existing `mouse_move`. clap already rejects `--output` combined with `--relative`.

## Backwards compatibility

Layer 2 mock-backend tests pass unchanged because the mock inherits the trait's default impl, which delegates to `list_outputs` + `mouse_move`. The shape and ordering of recorded calls is identical to before, so the existing `cli_pointer` tests for `--output` continue to pin the contract without modification.

## What's not tested

Layer 3 round-trip can't verify this fix because the headless wlroots cursor pipeline doesn't deliver pointer events to clients (see the long-standing limitation documented in `cli_roundtrip.rs`). Real-monitor verification stays in the pre-release manual matrix in `docs/verification/`.

The whole change is ~80 LOC: one trait method with default impl, the wlroots override, a small dispatch refactor.