### PR TITLE
Fix the libei timeout triad blocking KDE verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - libei backend: bumped the device-resume timeout from 5s to 15s. The old 5s was too tight for cold-start of `xdg-desktop-portal-kde`, which can take longer than 5s on a fresh boot. Override with `WDOTOOL_LIBEI_TIMEOUT_SECS=N` (any positive integer; values that don't parse as `u64` log a warning and fall back to the default).
 - libei backend: rewrote the device-resume timeout error to list candidate causes (dialog dismissed, portal cold-start, portal vended no device, capability mismatch) instead of asserting the user dismissed the dialog. Surfaced from a Plasma 6.6.4 / Manjaro report where the user accepted the dialog and still hit the timeout. Closes part of [#40](https://github.com/cushycush/wdotool/issues/40).
+- Backend detector: when a kde-dbus or gnome-ext init fails because its inner libei timed out, skip the bare-libei retry that comes next in the priority list. Previously the user waited the libei timeout twice in a row before seeing a real error. Closes [#40](https://github.com/cushycush/wdotool/issues/40).
 
 ## [0.5.0] — 2026-05-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- libei backend: bumped the device-resume timeout from 5s to 15s. The old 5s was too tight for cold-start of `xdg-desktop-portal-kde`, which can take longer than 5s on a fresh boot. Override with `WDOTOOL_LIBEI_TIMEOUT_SECS=N` (any positive integer; values that don't parse as `u64` log a warning and fall back to the default).
+- libei backend: rewrote the device-resume timeout error to list candidate causes (dialog dismissed, portal cold-start, portal vended no device, capability mismatch) instead of asserting the user dismissed the dialog. Surfaced from a Plasma 6.6.4 / Manjaro report where the user accepted the dialog and still hit the timeout. Closes part of [#40](https://github.com/cushycush/wdotool/issues/40).
+
 ## [0.5.0] — 2026-05-01
 
 ### Added

--- a/wdotool-core/src/backend/detector.rs
+++ b/wdotool-core/src/backend/detector.rs
@@ -153,13 +153,30 @@ pub async fn build(env: &Environment, forced: Option<BackendKind>) -> Result<Dyn
             // Walk the preference list; if the preferred backend fails to
             // bootstrap (portal unavailable, timeout, etc.) fall through to
             // the next. Only the final failure propagates.
+            //
+            // KDE and GNOME both compose LibeiBackend internally for input.
+            // If their init fails because libei itself timed out, retrying
+            // bare libei next does the same thing and times out again — net
+            // 2x wait before the user sees anything actionable. Track that
+            // case and skip the bare-libei retry.
             let order = priority(env);
             let mut last_err: Option<WdoError> = None;
+            let mut libei_just_failed = false;
             for kind in order {
+                if kind == BackendKind::Libei && libei_just_failed {
+                    debug!(
+                        backend = kind.label(),
+                        "skipping libei retry — it just failed via a composing backend"
+                    );
+                    continue;
+                }
                 info!(backend = kind.label(), "trying backend");
                 match build_one(kind).await {
                     Ok(b) => return Ok(b),
                     Err(err) => {
+                        if error_is_libei_failure(&err) {
+                            libei_just_failed = true;
+                        }
                         warn!(
                             backend = kind.label(),
                             ?err,
@@ -171,6 +188,18 @@ pub async fn build(env: &Environment, forced: Option<BackendKind>) -> Result<Dyn
             }
             Err(last_err.unwrap_or(WdoError::NoBackend))
         }
+    }
+}
+
+/// Returns true if `err` indicates a libei init failure — either a direct
+/// libei error, or a composing backend (kde-dbus, gnome-ext) reporting that
+/// its inner libei init failed. Used to skip a redundant bare-libei retry.
+fn error_is_libei_failure(err: &WdoError) -> bool {
+    match err {
+        WdoError::Backend { backend, source } => {
+            *backend == "libei" || source.to_string().contains("libei input init failed")
+        }
+        _ => false,
     }
 }
 
@@ -280,5 +309,53 @@ mod tests {
         assert!(env.desktop_is("GNOME"));
         assert!(env.desktop_is("ubuntu"));
         assert!(!env.desktop_is("KDE"));
+    }
+
+    #[test]
+    fn libei_failure_detected_on_direct_libei_error() {
+        let err = WdoError::Backend {
+            backend: "libei",
+            source: "timed out waiting for libei device after 15s".into(),
+        };
+        assert!(error_is_libei_failure(&err));
+    }
+
+    #[test]
+    fn libei_failure_detected_when_kde_wraps_libei_error() {
+        // kde.rs wraps inner libei errors with this exact prefix.
+        let err = WdoError::Backend {
+            backend: "kde-dbus",
+            source: "libei input init failed: timed out waiting for libei device".into(),
+        };
+        assert!(error_is_libei_failure(&err));
+    }
+
+    #[test]
+    fn libei_failure_detected_when_gnome_wraps_libei_error() {
+        let err = WdoError::Backend {
+            backend: "gnome-ext",
+            source: "libei input init failed: dispatcher ended before any device resumed".into(),
+        };
+        assert!(error_is_libei_failure(&err));
+    }
+
+    #[test]
+    fn libei_failure_not_detected_for_unrelated_kde_error() {
+        // KDE backend can fail for non-libei reasons (kwin script load, D-Bus
+        // service missing, etc.). Those should not suppress the libei retry.
+        let err = WdoError::Backend {
+            backend: "kde-dbus",
+            source: "kwin script load failed".into(),
+        };
+        assert!(!error_is_libei_failure(&err));
+    }
+
+    #[test]
+    fn libei_failure_not_detected_for_other_error_kinds() {
+        assert!(!error_is_libei_failure(&WdoError::NoBackend));
+        assert!(!error_is_libei_failure(&WdoError::NotSupported {
+            backend: "wlroots",
+            what: "no virtual_pointer",
+        }));
     }
 }

--- a/wdotool-core/src/backend/libei.rs
+++ b/wdotool-core/src/backend/libei.rs
@@ -96,9 +96,10 @@ impl LibeiBackend {
 
         let state = connection.state.clone();
 
-        // Wait up to 5s for the first device to resume. No sleep loop — the
-        // dispatcher fires the oneshot exactly when DeviceResumed arrives.
-        match tokio::time::timeout(Duration::from_secs(5), ready_rx).await {
+        // Wait for the first device to resume. No sleep loop — the dispatcher
+        // fires the oneshot exactly when DeviceResumed arrives.
+        let timeout_secs: u64 = 5;
+        match tokio::time::timeout(Duration::from_secs(timeout_secs), ready_rx).await {
             Ok(Ok(())) => {}
             Ok(Err(_)) => {
                 return Err(WdoError::Backend {
@@ -109,11 +110,18 @@ impl LibeiBackend {
             Err(_) => {
                 return Err(WdoError::Backend {
                     backend: NAME,
-                    source: "timed out waiting for libei device.\n\
-                             Common cause: the RemoteDesktop portal dialog was \
-                             dismissed or denied. Try again and accept, or check \
-                             your desktop's privacy / remote-desktop settings."
-                        .into(),
+                    source: format!(
+                        "timed out waiting for libei device after {timeout_secs}s.\n\
+                         Possible causes:\n  \
+                           - the RemoteDesktop portal dialog was dismissed or denied\n  \
+                           - portal cold-start took longer than the timeout \
+                             (KDE first-run can need more than {timeout_secs}s)\n  \
+                           - the portal accepted but didn't vend a usable input device\n  \
+                           - device negotiation didn't include a capability wdotool can drive\n\
+                         Check your desktop's privacy / remote-desktop settings and retry. \
+                         For portal logs: `journalctl --user -u 'xdg-desktop-portal*'`."
+                    )
+                    .into(),
                 });
             }
         }

--- a/wdotool-core/src/backend/libei.rs
+++ b/wdotool-core/src/backend/libei.rs
@@ -29,6 +29,34 @@ use crate::types::{Capabilities, KeyDirection, MouseButton, WindowId, WindowInfo
 
 const NAME: &str = "libei";
 
+/// Default seconds to wait for the libei portal to vend the first device.
+/// Set high enough to absorb cold-start of xdg-desktop-portal-kde, which
+/// can need over 5s on a fresh boot. Override with WDOTOOL_LIBEI_TIMEOUT_SECS.
+const DEFAULT_TIMEOUT_SECS: u64 = 15;
+const TIMEOUT_ENV_VAR: &str = "WDOTOOL_LIBEI_TIMEOUT_SECS";
+
+fn parse_timeout_secs(raw: Option<&str>) -> u64 {
+    let Some(value) = raw else {
+        return DEFAULT_TIMEOUT_SECS;
+    };
+    match value.trim().parse::<u64>() {
+        Ok(n) => n,
+        Err(_) => {
+            warn!(
+                var = TIMEOUT_ENV_VAR,
+                value,
+                default = DEFAULT_TIMEOUT_SECS,
+                "ignoring unparseable timeout env var, using default"
+            );
+            DEFAULT_TIMEOUT_SECS
+        }
+    }
+}
+
+fn libei_timeout_secs() -> u64 {
+    parse_timeout_secs(std::env::var(TIMEOUT_ENV_VAR).ok().as_deref())
+}
+
 pub struct LibeiBackend {
     state: Arc<Mutex<State>>,
     start: Instant,
@@ -98,7 +126,7 @@ impl LibeiBackend {
 
         // Wait for the first device to resume. No sleep loop — the dispatcher
         // fires the oneshot exactly when DeviceResumed arrives.
-        let timeout_secs: u64 = 5;
+        let timeout_secs = libei_timeout_secs();
         match tokio::time::timeout(Duration::from_secs(timeout_secs), ready_rx).await {
             Ok(Ok(())) => {}
             Ok(Err(_)) => {
@@ -115,7 +143,7 @@ impl LibeiBackend {
                          Possible causes:\n  \
                            - the RemoteDesktop portal dialog was dismissed or denied\n  \
                            - portal cold-start took longer than the timeout \
-                             (KDE first-run can need more than {timeout_secs}s)\n  \
+                             (extend it with {TIMEOUT_ENV_VAR}=30 or higher)\n  \
                            - the portal accepted but didn't vend a usable input device\n  \
                            - device negotiation didn't include a capability wdotool can drive\n\
                          Check your desktop's privacy / remote-desktop settings and retry. \
@@ -746,5 +774,30 @@ impl Backend for LibeiBackend {
             backend: NAME,
             what: "close_window — libei has no window API; pair with a WindowBackend",
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeout_default_when_unset() {
+        assert_eq!(parse_timeout_secs(None), DEFAULT_TIMEOUT_SECS);
+    }
+
+    #[test]
+    fn timeout_parses_valid_value() {
+        assert_eq!(parse_timeout_secs(Some("30")), 30);
+        assert_eq!(parse_timeout_secs(Some("1")), 1);
+        assert_eq!(parse_timeout_secs(Some("  45  ")), 45);
+    }
+
+    #[test]
+    fn timeout_falls_back_on_garbage() {
+        assert_eq!(parse_timeout_secs(Some("")), DEFAULT_TIMEOUT_SECS);
+        assert_eq!(parse_timeout_secs(Some("not-a-number")), DEFAULT_TIMEOUT_SECS);
+        assert_eq!(parse_timeout_secs(Some("-5")), DEFAULT_TIMEOUT_SECS);
+        assert_eq!(parse_timeout_secs(Some("3.5")), DEFAULT_TIMEOUT_SECS);
     }
 }

--- a/wdotool-core/src/backend/libei.rs
+++ b/wdotool-core/src/backend/libei.rs
@@ -796,7 +796,10 @@ mod tests {
     #[test]
     fn timeout_falls_back_on_garbage() {
         assert_eq!(parse_timeout_secs(Some("")), DEFAULT_TIMEOUT_SECS);
-        assert_eq!(parse_timeout_secs(Some("not-a-number")), DEFAULT_TIMEOUT_SECS);
+        assert_eq!(
+            parse_timeout_secs(Some("not-a-number")),
+            DEFAULT_TIMEOUT_SECS
+        );
         assert_eq!(parse_timeout_secs(Some("-5")), DEFAULT_TIMEOUT_SECS);
         assert_eq!(parse_timeout_secs(Some("3.5")), DEFAULT_TIMEOUT_SECS);
     }


### PR DESCRIPTION
Three fixes for the libei startup path, all surfaced when hron tried to verify the KDE backend on Plasma 6.6.4 / Manjaro for #1 and got stuck on every one of them. I filed #40 yesterday with the order; this is them.

First, the timeout error message stops lying. The hardcoded text claimed the user must have dismissed the dialog. hron accepted it and still hit the timeout, so the message pointed them at a non-existent fix. The new wording lists all four real candidates (dialog dismissed, portal cold-start slower than the timeout, portal vended no usable device, capability negotiation excluded everything wdotool can drive) and tells them where the portal logs live.

Second, the timeout default goes from 5s to 15s. Cold-start xdg-desktop-portal-kde takes longer than 5s on a fresh boot, which is the actual thing hron hit. 15s should absorb it. Anyone on a slower box can override at runtime with `WDOTOOL_LIBEI_TIMEOUT_SECS=N`, no rebuild. Garbage values log a warning and fall back to the default. The parse logic is a pure function with unit tests so it's covered without poking process state.

Third, the detector stops trying libei twice. When kde-dbus or gnome-ext fails because their inner libei timed out, the detector used to fall through to bare libei next, which runs the same libei attempt and times out the same way. With the new 15s default that's 30s wasted before the user sees a real error. Now it watches for libei failures (direct libei errors or the `libei input init failed` prefix that kde.rs and gnome.rs use when wrapping inner errors) and skips the bare-libei step when one fires. Five unit tests cover the matcher including a negative case (an unrelated kde error must NOT suppress the libei retry, since they're independent failures).

This unblocks #1. hron should be able to run the KDE matrix for real now: long enough timeout to survive cold-start, error that points somewhere useful if it still fails, no doomed 30s retry waiting for them.

Smoke-tested on Hyprland (`wdotool info` selects wlroots and works, `--backend libei` exits with the existing portal-not-found message because Hyprland doesn't expose RemoteDesktop). cargo build / clippy / fmt / test all clean across the workspace; 8 new unit tests added.

Closes #40.