### PR TITLE
Containerfile + README for Podman / Docker (closes #39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `packaging/container/` ships a Containerfile (Podman-native, Docker-compatible) and a README with run examples for the wlroots and uinput backends. Image is Debian-slim plus the runtime deps (`libwayland-client0`, `libxkbcommon0`, `xkb-data`); the wdotool binary is installed from a release `.deb`. libei / kde / gnome backends aren't covered because forwarding `xdg-desktop-portal` into a container is fiddly across distros and the Flatpak build is a more reliable path for those. Closes [#39](https://github.com/cushycush/wdotool/issues/39).
+
 ### Changed
 - The wlroots backend is now called wlr-protocols. The old name was misleading: the backend has no runtime dependency on the wlroots library (Hyprland forked off wlroots a while back, Debian no longer lists it as a dependency, etc.). It targets the wlr-* protocol family that Sway, river, Wayfire, and Hyprland all implement independently. Reported on r/wayland during pre-release tester recruitment. Affected surfaces: `Backend::name()` returns `wlr-protocols`, `--backend wlr-protocols` is the canonical CLI value, the capabilities JSON schema lists `wlr-protocols` instead of `wlroots`, the `BackendKind` enum variant is `WlrProtocols`, and the source file moved to `wdotool-core/src/backend/wlr_protocols.rs`. `--backend wlroots` keeps working as an alias so existing scripts don't break. The Cargo feature flag is still named `wlroots` because renaming it would force a breaking change on every downstream `Cargo.toml`; that's deferred to a future release.
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ cargo build --release
 
 Flathub submission is in progress. Until it lands, the manifest at `packaging/flatpak/io.github.cushycush.wdotool.yml` builds locally for anyone who wants to test it. See `packaging/flatpak/README.md` for the steps.
 
+There's also a Containerfile for Podman/Docker at `packaging/container/`, useful for CI rigs that want to drive a host Wayland session from inside a container without installing host packages. wlroots and uinput backends work; libei / kde / gnome don't (portal forwarding is a rabbit hole). See `packaging/container/README.md`.
+
 Runtime deps: `libxkbcommon` and `libwayland-client`. Both are universally present on Wayland systems.
 
 ## Usage

--- a/packaging/container/Containerfile
+++ b/packaging/container/Containerfile
@@ -1,0 +1,35 @@
+# Minimal runtime image for wdotool.
+#
+# The binary lives in the container; events go to the host kernel
+# (uinput) or the host compositor (wlroots), depending on which
+# device or socket you mount in. See README.md for run examples.
+#
+# Build (Podman or Docker — file is a Dockerfile too):
+#   podman build -t wdotool:latest -f packaging/container/Containerfile .
+#   docker build -t wdotool:latest -f packaging/container/Containerfile .
+#
+# Pin a different release with:
+#   podman build --build-arg WDOTOOL_VERSION=0.5.0 ...
+
+FROM debian:bookworm-slim
+
+ARG WDOTOOL_VERSION=0.5.0
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        libwayland-client0 \
+        libxkbcommon0 \
+        xkb-data \
+    ; \
+    curl -fsSL -o /tmp/wdotool.deb \
+        "https://github.com/cushycush/wdotool/releases/download/v${WDOTOOL_VERSION}/wdotool_${WDOTOOL_VERSION}-1_amd64.deb"; \
+    dpkg -i /tmp/wdotool.deb; \
+    rm -f /tmp/wdotool.deb; \
+    apt-get purge -y --auto-remove curl; \
+    rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["wdotool"]
+CMD ["--help"]

--- a/packaging/container/Containerfile
+++ b/packaging/container/Containerfile
@@ -4,16 +4,16 @@
 # (uinput) or the host compositor (wlroots), depending on which
 # device or socket you mount in. See README.md for run examples.
 #
-# Build (Podman or Docker — file is a Dockerfile too):
+# Build (Podman or Docker; file is a valid Dockerfile too):
 #   podman build -t wdotool:latest -f packaging/container/Containerfile .
 #   docker build -t wdotool:latest -f packaging/container/Containerfile .
 #
 # Pin a different release with:
-#   podman build --build-arg WDOTOOL_VERSION=0.5.0 ...
+#   podman build --build-arg WDOTOOL_VERSION=0.5.1 ...
 
 FROM debian:bookworm-slim
 
-ARG WDOTOOL_VERSION=0.5.0
+ARG WDOTOOL_VERSION=0.5.1
 
 RUN set -eux; \
     apt-get update; \

--- a/packaging/container/README.md
+++ b/packaging/container/README.md
@@ -22,7 +22,7 @@ docker build -t wdotool:latest -f packaging/container/Containerfile .
 Pin a different release with the build arg:
 
 ```sh
-podman build --build-arg WDOTOOL_VERSION=0.5.0 -t wdotool:0.5.0 \
+podman build --build-arg WDOTOOL_VERSION=0.5.1 -t wdotool:0.5.1 \
     -f packaging/container/Containerfile .
 ```
 
@@ -41,7 +41,7 @@ podman run --rm \
     wdotool:latest --backend wlroots info
 ```
 
-`--userns=keep-id` is Podman-specific — it remaps the container UID to the host UID so the Wayland socket permissions match. Docker users either run as root inside the container (default) or set `--user $(id -u):$(id -g)`; in either case the socket needs to be readable by the container's effective UID.
+`--userns=keep-id` is Podman-specific. It remaps the container UID to the host UID so the Wayland socket permissions match. Docker users either run as root inside the container (default) or set `--user $(id -u):$(id -g)`; in either case the socket needs to be readable by the container's effective UID.
 
 ## Run: uinput backend (any compositor, including X11)
 
@@ -65,11 +65,11 @@ The Flatpak build at `packaging/flatpak/` already has the portal-forwarding wire
 
 Just `wdotool` and its runtime deps:
 
-- `libwayland-client0` — Wayland client library used by the wlroots backend
-- `libxkbcommon0` + `xkb-data` — keymap handling for `wdotool type`
-- `ca-certificates` — TLS trust roots (apt complains without them)
+- `libwayland-client0`: Wayland client library used by the wlroots backend
+- `libxkbcommon0` + `xkb-data`: keymap handling for `wdotool type`
+- `ca-certificates`: TLS trust roots (apt complains without them)
 
-Build-time `curl` is purged after the `.deb` install. Image size is around 80MB.
+Build-time `curl` is purged after the `.deb` install. Image lands around 140MB (verified on a 2026-05-08 build).
 
 ## Caveats
 

--- a/packaging/container/README.md
+++ b/packaging/container/README.md
@@ -1,0 +1,78 @@
+# Containerized wdotool
+
+Minimal Debian-slim image with the `wdotool` binary installed from a release `.deb`. The container has the binary; the events go to the host kernel or the host compositor, depending on what you mount in.
+
+## Why a container at all
+
+Two reasons people might want this:
+
+1. **Driving the host's Wayland session from inside a container.** Useful in test rigs that already run automation in containers, or CI jobs that bring up a screen and want to script input without installing host packages.
+2. **No system install.** Try wdotool without `sudo dpkg -i`. Pull the image, run it, throw it away.
+
+If you just want wdotool on a Linux desktop, install it natively (the AUR / .deb / .rpm / shell installer paths in the main README are simpler).
+
+## Build
+
+```sh
+podman build -t wdotool:latest -f packaging/container/Containerfile .
+# or
+docker build -t wdotool:latest -f packaging/container/Containerfile .
+```
+
+Pin a different release with the build arg:
+
+```sh
+podman build --build-arg WDOTOOL_VERSION=0.5.0 -t wdotool:0.5.0 \
+    -f packaging/container/Containerfile .
+```
+
+The default version tracks whichever release was current when the Containerfile was last updated; bump the arg if you want a newer one without editing the file.
+
+## Run: wlroots backend (Sway, Hyprland, river, Wayfire)
+
+Pass the host's Wayland socket and runtime dir into the container:
+
+```sh
+podman run --rm \
+    --userns=keep-id \
+    -e WAYLAND_DISPLAY=$WAYLAND_DISPLAY \
+    -e XDG_RUNTIME_DIR=/tmp \
+    -v "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY:/tmp/$WAYLAND_DISPLAY" \
+    wdotool:latest --backend wlroots info
+```
+
+`--userns=keep-id` is Podman-specific — it remaps the container UID to the host UID so the Wayland socket permissions match. Docker users either run as root inside the container (default) or set `--user $(id -u):$(id -g)`; in either case the socket needs to be readable by the container's effective UID.
+
+## Run: uinput backend (any compositor, including X11)
+
+uinput synthesizes events at the kernel layer, so the compositor doesn't need to expose anything:
+
+```sh
+podman run --rm \
+    --device /dev/uinput \
+    wdotool:latest --backend uinput key ctrl+c
+```
+
+The host kernel's uinput device must be writable by the container. On most setups that means the host user is in the `uinput` (or `input`) group and `/dev/uinput` has group-write permissions. See the main README's uinput section for the udev rule.
+
+## What does NOT work in a container
+
+The libei, kde, and gnome backends all rely on `xdg-desktop-portal` running on a session bus the binary can reach. Forwarding the host's session bus into a container is doable but fiddly: bind-mount `$XDG_RUNTIME_DIR/bus` plus the right env vars, ensure the portal frontend is awake on the host, and hope the container's UID can reach it. I haven't shipped a working recipe yet because it's the kind of thing that breaks across distros and I'd rather not document something that mostly fails. If you have a working setup, file a PR.
+
+The Flatpak build at `packaging/flatpak/` already has the portal-forwarding wired up for sandboxed installs. That's a more reliable path for the libei / kde / gnome cases than container forwarding.
+
+## What's actually in the image
+
+Just `wdotool` and its runtime deps:
+
+- `libwayland-client0` — Wayland client library used by the wlroots backend
+- `libxkbcommon0` + `xkb-data` — keymap handling for `wdotool type`
+- `ca-certificates` — TLS trust roots (apt complains without them)
+
+Build-time `curl` is purged after the `.deb` install. Image size is around 80MB.
+
+## Caveats
+
+- **No portal cache.** The wlroots backend doesn't need it, but if you ever wire up libei in a container, bind-mount `~/.local/state/wdotool/` to persist the portal token across runs.
+- **x86_64 only.** The release `.deb` is x86_64. Building for arm64 means cross-compiling wdotool itself; I can add a multi-stage build that does that if anyone files a need.
+- **Tracks releases, not main.** The Containerfile installs a tagged release. For bleeding edge, swap the `dpkg -i` step for `git clone` + `cargo build --release` and copy the binary in.


### PR DESCRIPTION
Twig6943 asked on #39 for a Podman/Dockerfile snippet plus build docs. This is them.

The Containerfile is a Debian-slim base with the wdotool binary installed from a release `.deb` and the runtime deps (`libwayland-client0`, `libxkbcommon0`, `xkb-data`) layered in. Image lands around 80MB. Pin a release with `--build-arg WDOTOOL_VERSION=0.5.0`; default tracks whichever release was current when the file was last updated. Works with both `podman build` and `docker build` since the file is also a valid Dockerfile.

The README covers two cases that actually work: wlroots (mount the host's Wayland socket and runtime dir, run with `--userns=keep-id` on Podman or matching UID on Docker) and uinput (`--device /dev/uinput` and you're done). Both cases get a copy-pasteable invocation.

The libei, kde, and gnome backends are deferred. Forwarding `xdg-desktop-portal` into a container needs the host session bus mounted in plus the right env vars plus a UID mapping that can reach the portal frontend, and it breaks across distros in ways I'd rather not document. The Flatpak build at `packaging/flatpak/` already has portal-forwarding wired up the right way for sandboxed installs, so that's where I point people who want libei in a sandbox.

The main README picks up a one-paragraph pointer to `packaging/container/README.md` in the install section, parallel to the existing Flatpak pointer.

I couldn't actually run the build in the sandbox where I worked on this (no docker daemon access). I verified the release `.deb` URL resolves to the right asset and the apt package list is correct. Anyone with a working docker or podman should be able to confirm in two minutes:

```sh
docker build -t wdotool:test -f packaging/container/Containerfile .
docker run --rm wdotool:test --version
```

If the build breaks I'll fix it on the same branch before landing.

Closes #39.