### PR TITLE
Released v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] — 2026-05-08
+
 ### Changed
 - libei backend: bumped the device-resume timeout from 5s to 15s. The old 5s was too tight for cold-start of `xdg-desktop-portal-kde`, which can take longer than 5s on a fresh boot. Override with `WDOTOOL_LIBEI_TIMEOUT_SECS=N` (any positive integer; values that don't parse as `u64` log a warning and fall back to the default).
 - libei backend: rewrote the device-resume timeout error to list candidate causes (dialog dismissed, portal cold-start, portal vended no device, capability mismatch) instead of asserting the user dismissed the dialog. Surfaced from a Plasma 6.6.4 / Manjaro report where the user accepted the dialog and still hit the timeout. Closes part of [#40](https://github.com/cushycush/wdotool/issues/40).
@@ -151,7 +153,8 @@ Initial release.
 - GNOME window backend is not yet implemented.
 - `type_text` Unicode support is full on wlroots (transient keymap) but best-effort on libei/uinput (bounded by the compositor's active keymap).
 
-[Unreleased]: https://github.com/cushycush/wdotool/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/cushycush/wdotool/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/cushycush/wdotool/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/cushycush/wdotool/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/cushycush/wdotool/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/cushycush/wdotool/compare/v0.2.0...v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "wdotool"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "wdotool-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ashpd",
  "async-trait",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "wdotool-test-harness"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "libc",
  "rustix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["wdotool-core", "wdotool", "wdotool-test-harness"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cushycush/wdotool"

--- a/packaging/npm/package-lock.json
+++ b/packaging/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wdotool/capabilities",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wdotool/capabilities",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wdotool/capabilities",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "TypeScript types and JSON Schema for wdotool's `wdotool capabilities` output. Lets JS/TS consumers (wflows.com, dashboards, etc.) parse a capabilities report with full type safety.",
   "type": "module",
   "main": "dist/index.js",

--- a/wdotool/Cargo.toml
+++ b/wdotool/Cargo.toml
@@ -31,7 +31,7 @@ default = ["recorder"]
 recorder = ["wdotool-core/recorder"]
 
 [dependencies]
-wdotool-core = { path = "../wdotool-core", version = "0.5.0" }
+wdotool-core = { path = "../wdotool-core", version = "0.5.1" }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 regex = "1"


### PR DESCRIPTION
Patch release on top of v0.5.0 to ship the libei timeout triad fixes from #40 / #42. One verifier (hron, on #1) was already blocked on the 5s timeout and the misleading error; this gets them tested binaries instead of asking them to build from source.

What's in it:

- timeout default went from 5s to 15s, with `WDOTOOL_LIBEI_TIMEOUT_SECS=N` to push further without rebuilding
- error message lists the four real candidates and points at the portal journal, instead of falsely claiming the user dismissed the dialog
- detector skips the redundant bare-libei retry when kde-dbus or gnome-ext fail for libei reasons (no more 30s of pointless waiting on the new default)

Bumps `workspace.package.version`, `wdotool`'s `wdotool-core` path-dep, and `@wdotool/capabilities` npm package from 0.5.0 to 0.5.1. CHANGELOG `[Unreleased]` block moved into a dated `[0.5.1]` section, link refs at the bottom refreshed.

After merge I'll tag v0.5.1 on the merge commit, push the tag, and the existing release workflow does the rest (artifacts upload to GitHub Releases, AUR / crates.io / npm / distros workflows fan out).