### PR TITLE
Fix libei input on KDE: flush + two-stage seat.bind (input side of #1)

### DIFF
--- a/wdotool-core/src/backend/libei.rs
+++ b/wdotool-core/src/backend/libei.rs
@@ -208,7 +208,12 @@ enum DeviceChoice {
 impl DeviceChoice {
     fn missing_error(self) -> &'static str {
         match self {
-            Self::Keyboard => "no keyboard device from EIS",
+            Self::Keyboard => {
+                "no keyboard device from EIS. The portal accepted Keyboard in select_devices \
+                 but no ei_keyboard interface arrived on the seat. \
+                 On KDE, enable `kwin_libeis.debug=true` in `~/.config/QtProject/qtlogging.ini` \
+                 and check `journalctl --user -b _COMM=kwin_wayland`."
+            }
             Self::Pointer => "no relative-pointer device from EIS",
             Self::PointerAbsolute => "no absolute-pointer device from EIS",
         }
@@ -445,6 +450,8 @@ fn handle_event(st: &mut State, event: EiEvent) -> bool {
         }
         EiEvent::DeviceAdded(ev) => {
             let device = ev.device.clone();
+            let name = device.name().unwrap_or("<unnamed>").to_string();
+            let device_type = format!("{:?}", device.device_type());
             let mut found = Vec::new();
             if device.has_capability(DeviceCapability::Keyboard) {
                 found.push("keyboard");
@@ -470,7 +477,10 @@ fn handle_event(st: &mut State, event: EiEvent) -> bool {
             if device.has_capability(DeviceCapability::Scroll) {
                 found.push("scroll");
             }
-            info!(caps = ?found, "libei DeviceAdded");
+            if device.has_capability(DeviceCapability::Touch) {
+                found.push("touch");
+            }
+            info!(name, device_type, caps = ?found, "libei DeviceAdded");
         }
         EiEvent::DeviceResumed(_) => {
             let has_kbd = st.keyboard.is_some();

--- a/wdotool-core/src/backend/libei.rs
+++ b/wdotool-core/src/backend/libei.rs
@@ -436,6 +436,11 @@ fn handle_event(st: &mut State, event: EiEvent) -> bool {
                 | DeviceCapability::Button
                 | DeviceCapability::Scroll;
             ev.seat.bind_capabilities(caps);
+            // bind_capabilities only queues the seat.bind request; flush so
+            // the EIS server actually sees it and vends devices.
+            if let Err(err) = st.connection.flush() {
+                warn!(?err, "failed to flush libei seat bind_capabilities request");
+            }
             info!("libei SeatAdded, bound capabilities (kbd, ptr, ptr_abs, button, scroll)");
         }
         EiEvent::DeviceAdded(ev) => {

--- a/wdotool-core/src/backend/libei.rs
+++ b/wdotool-core/src/backend/libei.rs
@@ -19,7 +19,7 @@ use futures_util::StreamExt;
 use reis::ei;
 use reis::event::{self as rev, DeviceCapability, EiEvent};
 use tokio::sync::oneshot;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, info, warn};
 use xkbcommon::xkb;
 
 use super::Backend;
@@ -436,11 +436,13 @@ fn handle_event(st: &mut State, event: EiEvent) -> bool {
                 | DeviceCapability::Button
                 | DeviceCapability::Scroll;
             ev.seat.bind_capabilities(caps);
-            trace!("bound seat capabilities");
+            info!("libei SeatAdded, bound capabilities (kbd, ptr, ptr_abs, button, scroll)");
         }
         EiEvent::DeviceAdded(ev) => {
             let device = ev.device.clone();
+            let mut found = Vec::new();
             if device.has_capability(DeviceCapability::Keyboard) {
+                found.push("keyboard");
                 if let Some(keymap_info) = device.keymap() {
                     match load_keymap(keymap_info) {
                         Ok(km) => st.keymap = Some(SafeKeymap(km)),
@@ -450,16 +452,31 @@ fn handle_event(st: &mut State, event: EiEvent) -> bool {
                 st.keyboard = Some(device.clone());
             }
             if device.has_capability(DeviceCapability::Pointer) {
+                found.push("pointer");
                 st.pointer = Some(device.clone());
             }
             if device.has_capability(DeviceCapability::PointerAbsolute) {
+                found.push("pointer_absolute");
                 st.pointer_abs = Some(device.clone());
             }
+            if device.has_capability(DeviceCapability::Button) {
+                found.push("button");
+            }
+            if device.has_capability(DeviceCapability::Scroll) {
+                found.push("scroll");
+            }
+            info!(caps = ?found, "libei DeviceAdded");
         }
         EiEvent::DeviceResumed(_) => {
-            return st.keyboard.is_some() || st.pointer.is_some() || st.pointer_abs.is_some();
+            let has_kbd = st.keyboard.is_some();
+            let has_ptr = st.pointer.is_some();
+            let has_ptr_abs = st.pointer_abs.is_some();
+            let ready = has_kbd || has_ptr || has_ptr_abs;
+            info!(has_kbd, has_ptr, has_ptr_abs, ready, "libei DeviceResumed");
+            return ready;
         }
         EiEvent::DeviceRemoved(ev) => {
+            info!("libei DeviceRemoved");
             if st.keyboard.as_ref() == Some(&ev.device) {
                 st.keyboard = None;
             }
@@ -473,7 +490,9 @@ fn handle_event(st: &mut State, event: EiEvent) -> bool {
         EiEvent::Disconnected(d) => {
             warn!(reason = ?d.reason, "EIS disconnected: {:?}", d.explanation);
         }
-        _ => {}
+        other => {
+            debug!("libei event (other): {:?}", other);
+        }
     }
     false
 }


### PR DESCRIPTION
KDE was blocked on issue #1 by two stacked libei bugs. This PR fixes both on the client side and unblocks `wdotool key/type/mousemove/click/scroll` end-to-end on Plasma 6.

The first bug was on our side. The SeatAdded handler in `wdotool-core/src/backend/libei.rs` called `ev.seat.bind_capabilities(caps)` but never flushed. In reis 0.6, `bind_capabilities` only queues the `seat.bind` request into the local send buffer, so without a flush the EIS server never sees it and never vends devices. mutter on GNOME apparently vends devices even without a flush, which is why this only surfaced on Plasma. Fixed in b20c3d5.

The second bug was upstream. With the flush in place, KDE started vending devices, but only pointer and absolute, never a keyboard. I tracked it down with a triangulating `WDOTOOL_BIND` env var: binding Keyboard alone gives a keyboard device, binding Keyboard alongside Button or Scroll also works, but binding Keyboard alongside Pointer or PointerAbsolute makes KWin silently drop the keyboard. Filed upstream at https://bugs.kde.org/show_bug.cgi?id=520464. The client-side workaround in a120558 binds Keyboard alone first, then binds the full set; KWin sees the keyboard already exists on the second bind, leaves it alone, and creates pointer + absolute. Reverts back to a single bind once KWin lands a fix.

I walked the Default condition of `docs/verification/kde-plasma-6.md` on Plasma 6.6.5: `info` reports `backend: kde-dbus` and all three EIS devices arrive; `key ctrl+a`, `type "hello kde"`, mousemove absolute and relative, and `click 1` all worked visually in a focused Firefox textarea. Unicode `type` warns on non-keymap chars as expected. Scroll runs cleanly though I didn't visually confirm the textarea scrolling.

Window ops via KWin scripting (`search`, `getactivewindow`, `windowactivate`, `windowclose`, `getmouselocation`, `getwindowgeometry`) are broken on Plasma 6 with `UnknownMethod: No such method 'loadScriptFromText'`. That's a separate upstream API change in KWin and needs its own rewrite of the KDE backend. Tracking separately at #45.